### PR TITLE
Added `read_sequence_raw` function to fasta reader

### DIFF
--- a/noodles-fasta/src/reader.rs
+++ b/noodles-fasta/src/reader.rs
@@ -144,9 +144,10 @@ where
     /// reader.read_definition(&mut String::new())?;
     ///
     /// let mut buf = Vec::new();
-    /// reader.read_sequence_raw(&mut buf)?;
+    /// let read = reader.read_sequence_raw(&mut buf)?;
     ///
     /// assert_eq!(buf, b"ACGT\nTGCA\n\n");
+    /// assert_eq!(read, 11);
     /// # Ok::<(), io::Error>(())
     /// ```
     pub fn read_sequence_raw(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
@@ -159,11 +160,11 @@ where
                 break;
             }
 
-            let len = match memchr(NEWLINE, reader_buf) {
+            let len = match memchr(DEFINITION_PREFIX, reader_buf) {
                 Some(i) => {
-                    // Discard newline
-                    buf.extend(&reader_buf[..i + 1]);
-                    i + 1
+                    // Hit next >, do not consume it
+                    buf.extend(&reader_buf[..i]);
+                    i
                 }
                 None => {
                     buf.extend(reader_buf);

--- a/noodles-fasta/src/reader.rs
+++ b/noodles-fasta/src/reader.rs
@@ -73,7 +73,7 @@ where
     /// The position of the stream is expected to be at the start of a sequence, which is directly
     /// after a definition.
     ///
-    /// If successful, this returns the number of bytes read from the stream (including the excluded newlines). 
+    /// If successful, this returns the number of bytes read from the stream (including the excluded newlines).
     /// If the number of bytes read is 0, the stream reached EOF (though this case is likely an error).
     ///
     /// # Examples


### PR DESCRIPTION
I would like to implement the `fasta` index builder (discussion about index builders at #2): http://www.htslib.org/doc/faidx.html . The index requires line length information, which is currently discarded by `read_sequence` (the newlines are trimmer). The new function retains the newlines, allowing for inference of line length.

There is a lot of code repetition between `read_sequence` and `read_sequence_raw`, but I am unsure if switching `read_sequence` to filter out the newlines from a `read_sequence_raw` call would affect performance. 