### PR TITLE
Implementing DerefMut for sam::record::Data

### DIFF
--- a/noodles-sam/src/record.rs
+++ b/noodles-sam/src/record.rs
@@ -342,26 +342,27 @@ impl Record {
         &self.data
     }
 
-    /// Returns a mutable reference to the data fields
+    /// Returns a mutable reference to the data fields for this record.
     ///
     /// # Examples
     ///
     /// ```
-    /// use noodles_sam::{self as sam, record::{data, Data}};
+    /// use noodles_sam::{self as sam, record::data};
     ///
     /// let mut record = sam::Record::default();
     /// assert!(record.data().is_empty());
     ///
-    /// let data = record.data_mut();
-    /// data.insert(
+    /// let field = data::Field::new(
     ///     data::field::Tag::AlignmentHitCount,
-    ///     data::Field::new(
-    ///         data::field::Tag::AlignmentHitCount,
-    ///         data::field::Value::Int32(1),
-    ///     )
+    ///     data::field::Value::Int32(1),
     /// );
-    /// assert_eq!(record.data().to_string(), "NH:i:1");
-    /// # Ok::<(), data::TryFromFieldVectorError>(())
+    ///
+    /// let data = record.data_mut();
+    /// data.insert(field.tag().clone(), field.clone());
+    ///
+    /// let data = record.data();
+    /// assert_eq!(data.len(), 1);
+    /// assert_eq!(data.get(field.tag()), Some(&field));
     /// ```
     pub fn data_mut(&mut self) -> &mut Data {
         &mut self.data

--- a/noodles-sam/src/record.rs
+++ b/noodles-sam/src/record.rs
@@ -342,9 +342,27 @@ impl Record {
         &self.data
     }
 
-    /// Returns a mutable reference to data fields
+    /// Returns a mutable reference to the data fields
     ///
-    /// This is enough documentation I think
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_sam::{self as sam, record::{data, Data}};
+    ///
+    /// let mut record = sam::Record::default();
+    /// assert!(record.data().is_empty());
+    ///
+    /// let data = record.data_mut();
+    /// data.insert(
+    ///     data::field::Tag::AlignmentHitCount,
+    ///     data::Field::new(
+    ///         data::field::Tag::AlignmentHitCount,
+    ///         data::field::Value::Int32(1),
+    ///     )
+    /// );
+    /// assert_eq!(record.data().to_string(), "NH:i:1");
+    /// # Ok::<(), data::TryFromFieldVectorError>(())
+    /// ```
     pub fn data_mut(&mut self) -> &mut Data {
         &mut self.data
     }

--- a/noodles-sam/src/record.rs
+++ b/noodles-sam/src/record.rs
@@ -341,6 +341,13 @@ impl Record {
     pub fn data(&self) -> &Data {
         &self.data
     }
+
+    /// Returns a mutable reference to data fields
+    ///
+    /// This is enough documentation I think
+    pub fn data_mut(&mut self) -> &mut Data {
+        &mut self.data
+    }
 }
 
 impl Default for Record {

--- a/noodles-sam/src/record/data.rs
+++ b/noodles-sam/src/record/data.rs
@@ -4,7 +4,12 @@ pub mod field;
 
 pub use self::field::Field;
 
-use std::{convert::TryFrom, error, fmt, ops::Deref, str::FromStr};
+use std::{
+    convert::TryFrom,
+    error, fmt,
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
 use indexmap::IndexMap;
 
@@ -21,6 +26,12 @@ impl Deref for Data {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl DerefMut for Data {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 


### PR DESCRIPTION
Now that I've got the code from #15 working it really opened the floodgates 😁 

My next target: reading a BAM file, filtering by checking for a specific tag, and then writing a slightly modified BAM file with a new tag added. Specifically I'm checking for a barcode tag that's part of my selected set, and then adding a corrected barcode in a new tag and writing it to my new BAM file.

Unfortunately I got stuck on the last step. I could create a new `sam::Record` with the additional tag, but it felt clumsy to me--it didn't appear that there was a natural way to copy things, so I would need to use `Record::builder` and manually set all the fields (including checking for errors).

I thought maybe I could use the Rust structure-copying method of `Record{ data: new_data, ..old_record }` but all of the fields are private so it won't let me do that.

One way that I saw that would make this work is if I could borrow a mutable pointer to the Record's data, e.g. 

```
let mut sam_record = record.try_into_sam_record(header.reference_sequences())?;
let sam_data = sam_record.data_mut();
sam_data.insert(my_new_tag, my_new_field);
writer.write_sam_record(header.reference_sequences(), &sam_record)?;
```

I needed to implement `DerefMut` for the Data struct and add `data_mut` to the Record struct. That's what this PR does, and it works!

You might prefer to keep everything immutable instead of allowing this, which I can understand. In that case I'd request a more convenient way to modify an existing record, as (at least for me) modifying a record with some new data is a pretty common use-case.