### PR TITLE
Make `seek_to_first_record` public

### DIFF
--- a/noodles-bam/src/reader.rs
+++ b/noodles-bam/src/reader.rs
@@ -262,7 +262,7 @@ where
 
     // Seeks to the first record by setting the cursor to the beginning of the stream and
     // (re)reading the header and binary reference sequences.
-    fn seek_to_first_record(&mut self) -> io::Result<VirtualPosition> {
+    pub fn seek_to_first_record(&mut self) -> io::Result<VirtualPosition> {
         self.seek(VirtualPosition::default())?;
         self.read_header()?;
         self.read_reference_sequences()?;

--- a/noodles-bam/src/reader.rs
+++ b/noodles-bam/src/reader.rs
@@ -260,8 +260,18 @@ where
         self.inner.seek(pos)
     }
 
-    // Seeks to the first record by setting the cursor to the beginning of the stream and
-    // (re)reading the header and binary reference sequences.
+    /// Seeks to the first record by setting the cursor to the beginning of the stream and
+    /// (re)reading the header and binary reference sequences.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use noodles_bam as bam;
+    ///
+    /// let mut reader = File::open("sample.bam").map(bam::Reader::new)?;
+    /// reader.seek_to_first_record()?;
+    /// # Ok::<(), io::Error>(())
+    /// ```
     pub fn seek_to_first_record(&mut self) -> io::Result<VirtualPosition> {
         self.seek(VirtualPosition::default())?;
         self.read_header()?;

--- a/noodles-bam/src/reader.rs
+++ b/noodles-bam/src/reader.rs
@@ -266,6 +266,7 @@ where
     /// # Examples
     ///
     /// ```no_run
+    /// # use std::{fs::File, io};
     /// use noodles_bam as bam;
     ///
     /// let mut reader = File::open("sample.bam").map(bam::Reader::new)?;


### PR DESCRIPTION
Tiny tweak that I think is worth making: the method `seek_to_first_record` would be nice to have available as a public method as it removes a little boilerplate for simple scripts.

In my case I need to read through the BAM twice so it's handy to have this available (and I don't need to bring `VirtualPosition` into my module).