### PR TITLE
builder methods should take ownership

### DIFF
--- a/noodles-bam/src/async/reader/builder.rs
+++ b/noodles-bam/src/async/reader/builder.rs
@@ -31,7 +31,7 @@ where
     /// let data = [];
     /// let builder = bam::AsyncReader::builder(&data[..]).set_worker_count(8);
     /// ```
-    pub fn set_worker_count(&mut self, worker_count: usize) -> &mut Self {
+    pub fn set_worker_count(mut self, worker_count: usize) -> Self {
         self.worker_count = Some(worker_count);
         self
     }

--- a/noodles-bam/src/async/writer/builder.rs
+++ b/noodles-bam/src/async/writer/builder.rs
@@ -36,7 +36,7 @@ where
     /// let builder = bam::AsyncWriter::builder(Vec::new())
     ///     .set_compression_level(Compression::best());
     /// ```
-    pub fn set_compression_level(&mut self, compression_level: Compression) -> &mut Self {
+    pub fn set_compression_level(mut self, compression_level: Compression) -> Self {
         self.compression_level = Some(compression_level);
         self
     }
@@ -51,7 +51,7 @@ where
     /// use noodles_bam as bam;
     /// let builder = bam::AsyncWriter::builder(Vec::new()).set_worker_count(8);
     /// ```
-    pub fn set_worker_count(&mut self, worker_count: usize) -> &mut Self {
+    pub fn set_worker_count(mut self, worker_count: usize) -> Self {
         self.worker_count = Some(worker_count);
         self
     }


### PR DESCRIPTION
I was excited to try out the new multi-threaded async functions, but I ran into what I think is a bug. If I try to build an AsyncWriter using the Builder and `set_worker_count`, it will fail to compile with

```
error[E0507]: cannot move out of a mutable reference
  --> src/retag_bam.rs:54:22
   |
54 |       let mut writer = bam::AsyncWriter::builder(file)
   |  ______________________^
55 | |         .set_worker_count(8)
56 | |         .set_compression_level(Compression::fast())
   | |___________________________________________________^ move occurs because value has type `bam::r#async::writer::builder::Builder<tokio::fs::File>`, which does not implement the `Copy` trait

error: aborting due to previous error
```

I believe this is because the builder methods were by reference, and they need to take ownership to return the modified object.

I only modified the bam::AsyncWriter::Builder object here but if you think this is the right change I am happy to make the same tweak for other Builders.