### PR TITLE
Expose types in public interfaces

### DIFF
--- a/noodles-bcf/src/lib.rs
+++ b/noodles-bcf/src/lib.rs
@@ -10,7 +10,11 @@ mod reader;
 mod record;
 mod writer;
 
-pub use self::{reader::Reader, record::Record, writer::Writer};
+pub use self::{
+    reader::{Query, Reader, Records},
+    record::Record,
+    writer::Writer,
+};
 
 #[cfg(feature = "async")]
 pub use self::r#async::Reader as AsyncReader;

--- a/noodles-bcf/src/lib.rs
+++ b/noodles-bcf/src/lib.rs
@@ -6,15 +6,11 @@
 mod r#async;
 
 pub mod header;
-mod reader;
+pub mod reader;
 mod record;
 mod writer;
 
-pub use self::{
-    reader::{Query, Reader, Records},
-    record::Record,
-    writer::Writer,
-};
+pub use self::{reader::Reader, record::Record, writer::Writer};
 
 #[cfg(feature = "async")]
 pub use self::r#async::Reader as AsyncReader;

--- a/noodles-vcf/src/lib.rs
+++ b/noodles-vcf/src/lib.rs
@@ -24,16 +24,11 @@
 mod r#async;
 
 pub mod header;
-mod reader;
+pub mod reader;
 pub mod record;
 mod writer;
 
-pub use self::{
-    header::Header,
-    reader::{Query, Reader, Records},
-    record::Record,
-    writer::Writer,
-};
+pub use self::{header::Header, reader::Reader, record::Record, writer::Writer};
 
 #[cfg(feature = "async")]
 pub use self::r#async::{Reader as AsyncReader, Writer as AsyncWriter};

--- a/noodles-vcf/src/lib.rs
+++ b/noodles-vcf/src/lib.rs
@@ -28,7 +28,12 @@ mod reader;
 pub mod record;
 mod writer;
 
-pub use self::{header::Header, reader::Reader, record::Record, writer::Writer};
+pub use self::{
+    header::Header,
+    reader::{Query, Reader, Records},
+    record::Record,
+    writer::Writer,
+};
 
 #[cfg(feature = "async")]
 pub use self::r#async::{Reader as AsyncReader, Writer as AsyncWriter};


### PR DESCRIPTION
I was playing around with some extensions to the `vcf`/`bcf` modules, and found that certain things are made difficult by the fact that some returned structs (`Records` and `Query` in `noodles-{vcf,bcf}`) are not exported, and hence cannot be referenced from outside `noodles`. I see that similar structs are exported in other parts of `noodles`, so I assume this is unintentional and made this small PR to fix.

For completeness sake, I started going through some of the other sub-crates to see if I could find other instances of the same pattern. I can find it in a few other places (e.g. `CompressionHeader`, `Container` in `noodles-cram`), but there I'm less sure if for some reason this is intentional, and, if not, what export structure you might prefer. Happy to help if you want to outsource something.

Thanks as always for your work on this!