### PR TITLE
Access genotype alleles (Fixes #42)

### DIFF
--- a/noodles-vcf/src/record/genotype/field/value/genotype.rs
+++ b/noodles-vcf/src/record/genotype/field/value/genotype.rs
@@ -4,7 +4,12 @@ pub mod allele;
 
 pub use self::allele::Allele;
 
-use std::{convert::TryFrom, error, fmt, ops::Deref, str::FromStr};
+use std::{
+    convert::TryFrom,
+    error, fmt,
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
 /// A VCF record genotype value.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -15,6 +20,12 @@ impl Deref for Genotype {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl DerefMut for Genotype {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/noodles-vcf/src/record/genotype/field/value/genotype.rs
+++ b/noodles-vcf/src/record/genotype/field/value/genotype.rs
@@ -165,30 +165,23 @@ mod tests {
     }
 
     #[test]
-    fn test_try_from_alleles() {
+    fn test_try_from_alleles_for_genotype() {
         use allele::Phasing;
 
-        let correct_alleles = vec![
+        let expected = Genotype(vec![
             Allele::new(Some(0), None),
             Allele::new(Some(1), Some(Phasing::Unphased)),
-        ];
+        ]);
+        assert_eq!(Genotype::try_from(expected.0.clone()), Ok(expected));
 
         assert_eq!(
-            Genotype::try_from(correct_alleles.clone()),
-            Ok(Genotype(correct_alleles))
-        );
-
-        assert_eq!(
-            Genotype::try_from(vec![
-                Allele::new(Some(0), Some(Phasing::Unphased)),
-                Allele::new(Some(1), Some(Phasing::Unphased)),
-            ]),
+            Genotype::try_from(vec![Allele::new(Some(0), Some(Phasing::Unphased))]),
             Err(TryFromAllelesError::InvalidFirstAllelePhasing),
         );
 
         assert_eq!(
             Genotype::try_from(Vec::new()),
-            Err(TryFromAllelesError::Empty),
+            Err(TryFromAllelesError::Empty)
         );
     }
 }

--- a/noodles-vcf/src/record/genotype/field/value/genotype.rs
+++ b/noodles-vcf/src/record/genotype/field/value/genotype.rs
@@ -4,11 +4,19 @@ pub mod allele;
 
 pub use self::allele::Allele;
 
-use std::{error, fmt, str::FromStr};
+use std::{error, fmt, ops::Deref, str::FromStr};
 
 /// A VCF record genotype value.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Genotype(Vec<Allele>);
+
+impl Deref for Genotype {
+    type Target = [Allele];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// An error returned when a raw VCF record genotype value fails to parse.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/noodles-vcf/src/record/genotype/field/value/genotype/allele.rs
+++ b/noodles-vcf/src/record/genotype/field/value/genotype/allele.rs
@@ -29,21 +29,55 @@ impl Allele {
     }
 
     /// Returns the phasing of the allele.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf::record::genotype::field::value::genotype::Allele;
+    /// let allele = Allele::new(Some(0), None);
+    /// assert!(allele.phasing().is_none());
+    /// ```
     pub fn phasing(&self) -> Option<Phasing> {
         self.phasing
     }
 
     /// Returns a mutable reference to the phasing of the allele.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf::record::genotype::field::value::genotype::{allele::Phasing, Allele};
+    /// let mut allele = Allele::new(Some(0), None);
+    /// *allele.phasing_mut() = Some(Phasing::Unphased);
+    /// assert_eq!(allele.phasing(), Some(Phasing::Unphased));
+    /// ```
     pub fn phasing_mut(&mut self) -> &mut Option<Phasing> {
         &mut self.phasing
     }
 
     /// Returns the position of the allele.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf::record::genotype::field::value::genotype::Allele;
+    /// let allele = Allele::new(Some(0), None);
+    /// assert_eq!(allele.position(), Some(0));
+    /// ```
     pub fn position(&self) -> Option<usize> {
         self.position
     }
 
     /// Returns a mutable reference to the position of the allele.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf::record::genotype::field::value::genotype::Allele;
+    /// let mut allele = Allele::new(Some(0), None);
+    /// *allele.position_mut() = Some(1);
+    /// assert_eq!(allele.position(), Some(1));
+    /// ```
     pub fn position_mut(&mut self) -> &mut Option<usize> {
         &mut self.position
     }

--- a/noodles-vcf/src/record/genotype/field/value/genotype/allele.rs
+++ b/noodles-vcf/src/record/genotype/field/value/genotype/allele.rs
@@ -28,33 +28,6 @@ impl Allele {
         Self { position, phasing }
     }
 
-    /// Returns the phasing of the allele.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use noodles_vcf::record::genotype::field::value::genotype::Allele;
-    /// let allele = Allele::new(Some(0), None);
-    /// assert!(allele.phasing().is_none());
-    /// ```
-    pub fn phasing(&self) -> Option<Phasing> {
-        self.phasing
-    }
-
-    /// Returns a mutable reference to the phasing of the allele.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use noodles_vcf::record::genotype::field::value::genotype::{allele::Phasing, Allele};
-    /// let mut allele = Allele::new(Some(0), None);
-    /// *allele.phasing_mut() = Some(Phasing::Unphased);
-    /// assert_eq!(allele.phasing(), Some(Phasing::Unphased));
-    /// ```
-    pub fn phasing_mut(&mut self) -> &mut Option<Phasing> {
-        &mut self.phasing
-    }
-
     /// Returns the position of the allele.
     ///
     /// # Examples
@@ -80,6 +53,33 @@ impl Allele {
     /// ```
     pub fn position_mut(&mut self) -> &mut Option<usize> {
         &mut self.position
+    }
+
+    /// Returns the phasing of the allele.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf::record::genotype::field::value::genotype::Allele;
+    /// let allele = Allele::new(Some(0), None);
+    /// assert!(allele.phasing().is_none());
+    /// ```
+    pub fn phasing(&self) -> Option<Phasing> {
+        self.phasing
+    }
+
+    /// Returns a mutable reference to the phasing of the allele.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf::record::genotype::field::value::genotype::{allele::Phasing, Allele};
+    /// let mut allele = Allele::new(Some(0), None);
+    /// *allele.phasing_mut() = Some(Phasing::Unphased);
+    /// assert_eq!(allele.phasing(), Some(Phasing::Unphased));
+    /// ```
+    pub fn phasing_mut(&mut self) -> &mut Option<Phasing> {
+        &mut self.phasing
     }
 }
 

--- a/noodles-vcf/src/record/genotype/field/value/genotype/allele.rs
+++ b/noodles-vcf/src/record/genotype/field/value/genotype/allele.rs
@@ -28,6 +28,11 @@ impl Allele {
         Self { position, phasing }
     }
 
+    /// Returns the phasing of the allele.
+    pub fn phasing(&self) -> Option<Phasing> {
+        self.phasing
+    }
+
     /// Returns the position of the allele.
     pub fn position(&self) -> Option<usize> {
         self.position

--- a/noodles-vcf/src/record/genotype/field/value/genotype/allele.rs
+++ b/noodles-vcf/src/record/genotype/field/value/genotype/allele.rs
@@ -27,6 +27,11 @@ impl Allele {
     pub fn new(position: Option<usize>, phasing: Option<Phasing>) -> Self {
         Self { position, phasing }
     }
+
+    /// Returns the position of the allele.
+    pub fn position(&self) -> Option<usize> {
+        self.position
+    }
 }
 
 /// An error returned when a raw VCF record genotype value allele fails to parse.

--- a/noodles-vcf/src/record/genotype/field/value/genotype/allele.rs
+++ b/noodles-vcf/src/record/genotype/field/value/genotype/allele.rs
@@ -33,9 +33,19 @@ impl Allele {
         self.phasing
     }
 
+    /// Returns a mutable reference to the phasing of the allele.
+    pub fn phasing_mut(&mut self) -> &mut Option<Phasing> {
+        &mut self.phasing
+    }
+
     /// Returns the position of the allele.
     pub fn position(&self) -> Option<usize> {
         self.position
+    }
+
+    /// Returns a mutable reference to the position of the allele.
+    pub fn position_mut(&mut self) -> &mut Option<usize> {
+        &mut self.position
     }
 }
 


### PR DESCRIPTION
Here were the basics discussed in #42. I was thinking the following might also be desirable:

1. Implement mutable getters for `position` and `phasing` for `Allele`.
2. Implement a public constructor for `Genotype`, as `pub fn new(alleles: Vec<Allele>) -> Self` and/or `From<Vec<Allele>> for Genotype`.
3. Implement `DerefMut<Target = [Allele]> for Genotype`.

However, I suppose these depend on how you envision `Genotype` being used in practice, so I thought you'd perhaps like to give some input on those before I forged ahead.