### PR TITLE
bam/writer, sam/writer: Validate cigar/sequence/basequalities

### DIFF
--- a/noodles-bam/src/async/writer.rs
+++ b/noodles-bam/src/async/writer.rs
@@ -7,7 +7,7 @@ pub use self::builder::Builder;
 use std::ffi::CString;
 
 use noodles_bgzf as bgzf;
-use noodles_sam as sam;
+use noodles_sam::{self as sam, validate};
 use tokio::io::{self, AsyncWrite, AsyncWriteExt};
 
 use crate::Record;
@@ -167,6 +167,7 @@ where
         reference_sequences: &sam::header::ReferenceSequences,
         record: &sam::Record,
     ) -> io::Result<()> {
+        validate(record)?;
         sam_record::write_sam_record(&mut self.inner, reference_sequences, record).await
     }
 }

--- a/noodles-bam/src/async/writer/sam_record.rs
+++ b/noodles-bam/src/async/writer/sam_record.rs
@@ -54,7 +54,7 @@ where
         reference_sequences,
         record.reference_sequence_name(),
     )
-        .await?;
+    .await?;
 
     // pos
     write_position(writer, record.position()).await?;
@@ -83,7 +83,7 @@ where
         reference_sequences,
         record.mate_reference_sequence_name(),
     )
-        .await?;
+    .await?;
 
     // next_pos
     write_position(writer, record.mate_position()).await?;
@@ -104,7 +104,6 @@ where
 
     let quality_scores = record.quality_scores();
     if quality_scores.is_empty() {
-
         // qual
         write_missing_filled_quality_scores(writer, sequence.len()).await?;
     } else {

--- a/noodles-bam/src/bai/index/builder.rs
+++ b/noodles-bam/src/bai/index/builder.rs
@@ -132,6 +132,7 @@ mod tests {
                 .set_reference_sequence_name("sq0".parse()?)
                 .set_position(Position::try_from(2)?)
                 .set_cigar("4M".parse()?)
+                .set_sequence("CGAT".parse()?)
                 .build()?,
         )?;
 

--- a/noodles-bam/src/bai/index/reference_sequence/builder.rs
+++ b/noodles-bam/src/bai/index/reference_sequence/builder.rs
@@ -141,6 +141,7 @@ mod tests {
                 .set_flags(Flags::empty())
                 .set_position(Position::try_from(2)?)
                 .set_cigar("4M".parse()?)
+                .set_sequence("CGAT".parse()?)
                 .build()?,
         )?;
 
@@ -157,6 +158,7 @@ mod tests {
             &sam::Record::builder()
                 .set_position(Position::try_from(6)?)
                 .set_cigar("2M".parse()?)
+                .set_sequence("CG".parse()?)
                 .build()?,
         )?;
 

--- a/noodles-bam/src/lib.rs
+++ b/noodles-bam/src/lib.rs
@@ -57,7 +57,7 @@ pub mod reader;
 pub mod record;
 mod writer;
 
-pub use self::{reader::Reader, record::Record, writer::Writer};
+pub use self::{reader::Reader, record::Record, writer::validate, writer::Writer};
 
 #[cfg(feature = "async")]
 pub use self::r#async::{Reader as AsyncReader, Writer as AsyncWriter};

--- a/noodles-sam/src/async/writer.rs
+++ b/noodles-sam/src/async/writer.rs
@@ -1,6 +1,6 @@
 use tokio::io::{self, AsyncWrite, AsyncWriteExt};
 
-use crate::{Header, Record};
+use crate::{validate, Header, Record};
 
 /// An async SAM writer.
 pub struct Writer<W>
@@ -99,6 +99,8 @@ where
     /// ```
     pub async fn write_record(&mut self, record: &Record) -> io::Result<()> {
         const LINE_FEED: u8 = b'\n';
+
+        validate(record)?;
 
         let raw_record = record.to_string();
         self.inner.write_all(raw_record.as_bytes()).await?;

--- a/noodles-sam/src/lib.rs
+++ b/noodles-sam/src/lib.rs
@@ -41,7 +41,8 @@ mod record_ext;
 mod writer;
 
 pub use self::{
-    header::Header, reader::Reader, record::Record, record_ext::RecordExt, writer::Writer,
+    header::Header, reader::Reader, record::Record, record_ext::RecordExt, writer::validate,
+    writer::Writer,
 };
 
 #[cfg(feature = "async")]

--- a/noodles-sam/src/writer.rs
+++ b/noodles-sam/src/writer.rs
@@ -115,8 +115,46 @@ where
     /// # Ok::<(), io::Error>(())
     /// ```
     pub fn write_record(&mut self, record: &Record) -> io::Result<()> {
+        validate(record)?;
         writeln!(self.inner, "{}", record)
     }
+}
+
+/// Validate SAM field relations
+pub fn validate(record: &Record) -> io::Result<()> {
+    // Before writing validate record requirements for BAM encoding
+    // Sequence and quality must be same length
+    // If no qualities are present use 0xFF as placeholders
+    // https://samtools.github.io/hts-specs/SAMv1.pdf#subsubsection.4.2.3
+    let sequence_len = record.sequence().len();
+    let quality_scores_len = record.quality_scores().len();
+
+    if quality_scores_len > 0 && quality_scores_len != sequence_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "quality scores length mismatch: expected {}, got {}",
+                sequence_len, quality_scores_len
+            ),
+        ));
+    }
+
+    // The sum of the query consuming CIGAR operations must equal the SEQ length
+    // https://samtools.github.io/hts-specs/SAMv1.pdf#subsubsection.4.2.2
+    let sequence_len =
+        u32::try_from(sequence_len).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let cigar_query_len = record.cigar().read_len();
+    if cigar_query_len != sequence_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "cigar operations length mismatch: expected {}, got {}",
+                sequence_len, cigar_query_len
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
To avoid writing corrupt or incompatible SAM/BAM files an extra
validation step is applied before writing. This makes sure:
 - The number of base qualities is equal to the sequence length or empty
 - The length of the cigar operations matches the sequence length

Closes #59