### PR TITLE
noodles-sam: fix reader to parse some edge cases

### DIFF
--- a/noodles-sam/src/record/builder.rs
+++ b/noodles-sam/src/record/builder.rs
@@ -325,7 +325,7 @@ impl Builder {
     pub fn build(self) -> Result<Record, BuildError> {
         // § 1.4 The alignment section: mandatory fields (2021-06-03): "If not a '*', the length of
         // the sequence must equal the sum of lengths of `M/I/S/=/X` operations in `CIGAR`."
-        if !self.flags.is_unmapped() && !self.sequence.is_empty() {
+        if !self.flags.is_unmapped() && !self.sequence.is_empty() && !self.cigar.is_empty() {
             let sequence_len = self.sequence.len() as u32;
             let cigar_read_len = self.cigar.read_len();
 

--- a/noodles-sam/src/record/data/field/value.rs
+++ b/noodles-sam/src/record/data/field/value.rs
@@ -791,7 +791,6 @@ mod tests {
         assert_eq!("Z:🍜".parse::<Value>(), Err(ParseError::InvalidStringValue));
 
         assert_eq!("H:CAFE".parse(), Ok(Value::Hex(String::from("CAFE"))));
-        assert_eq!("H:cafe".parse::<Value>(), Err(ParseError::InvalidHexValue));
         assert_eq!("H:CAFE0".parse::<Value>(), Err(ParseError::InvalidHexValue));
         assert_eq!("H:NDLS".parse::<Value>(), Err(ParseError::InvalidHexValue));
 

--- a/noodles-sam/src/record/data/field/value.rs
+++ b/noodles-sam/src/record/data/field/value.rs
@@ -642,7 +642,7 @@ fn parse_string(s: &str) -> Result<String, ParseError> {
 
 // § 1.5 The alignment section: optional fields (2021-01-07)
 fn is_valid_hex_char(c: char) -> bool {
-    matches!(c, '0'..='9' | 'A'..='F')
+    matches!(c, '0'..='9' | 'A'..='F' | 'a'..='f')
 }
 
 fn parse_hex(s: &str) -> Result<String, ParseError> {


### PR DESCRIPTION
I was playing with the tests for SAM defined in the [hts-specs repo](https://github.com/samtools/hts-specs/tree/master/test/sam).

I used a simple [bash script](https://gist.github.com/veldsla/260e8f5f7e09cb82e73fba6348ed9158) and the sam_view example to read the files.

There are two sets, passed and failed.
The fail tests are a bit odd. Most also don't fail a `samtools view` so it's difficult to decide.

All the pass test parse with `samtools view`, but a couple don't with `sam_view`

This PR fixes 2 of those edge cases:
 - The hex value in a field maybe in lowercase
 - A cigar line maybe missing (*) but can the read can still be mapped and have a sequence (this used to trigger a `SequenceLengthMismatch`)

Now 2 test still fail to parse, but it seems this is an issue with the test (duplicate tags).

The bash script also compares the output of the view commands and there are some differences in the handling between noodles and samtools:
 - Samtools replaces invalid bases in the sequence with N
 - Samtools adjust the flags when it decides the read cannot be mapped based on other fields

Not sure what to to with this.


-edit And of course I didn't run the tests...shame on me. Removed the expected error on the lowercase hex `cafe`. Was also a bit strange because it's even in the examples somewhere:
`assert_eq!(Value::Hex(String::from("cafe")).as_hex(), Some("cafe"));`