### PR TITLE
Add mutable access to VCF record

### DIFF
--- a/noodles-vcf/CHANGELOG.md
+++ b/noodles-vcf/CHANGELOG.md
@@ -12,9 +12,15 @@
   * vcf/record: Add mutable getters for genotypes, reference bases, and
     alternate bases.
 
+  * vcf/record/genotypes: Add mutable getter for keys.
+
   * vcf/record/reference_bases: Implement `DerefMut`.
 
   * vcf/record/alternate_bases: Implement `DerefMut`.
+
+  * vcf/record/genotypes/keys: Implement `DerefMut`.
+
+  * vcf/record/genotypes/genotype: Implement `DerefMut`.
 
 ## 0.11.1 - 2021-12-09
 

--- a/noodles-vcf/CHANGELOG.md
+++ b/noodles-vcf/CHANGELOG.md
@@ -9,6 +9,13 @@
   * vcf/header: Add immutable and mutable getters for unstructured
     `vcf::Header` fields.
 
+  * vcf/record: Add mutable getters for genotypes, reference bases, and
+    alternate bases.
+
+  * vcf/record/reference_bases: Implement `DerefMut`.
+
+  * vcf/record/alternate_bases: Implement `DerefMut`.
+
 ## 0.11.1 - 2021-12-09
 
 ### Fixed

--- a/noodles-vcf/src/record.rs
+++ b/noodles-vcf/src/record.rs
@@ -248,6 +248,36 @@ impl Record {
         &self.reference_bases
     }
 
+    /// Returns a mutable reference to the reference bases of the record.
+    ///
+    /// This is a required field and guaranteed to be nonempty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf::{
+    ///     self as vcf,
+    ///     record::{reference_bases::Base, Position, ReferenceBases},
+    /// };
+    ///
+    /// let mut record = vcf::Record::builder()
+    ///     .set_chromosome("sq0".parse()?)
+    ///     .set_position(Position::try_from(1)?)
+    ///     .set_reference_bases("A".parse()?)
+    ///     .build()?;
+    ///
+    /// *record.reference_bases_mut() = "T".parse()?;
+    ///
+    /// assert_eq!(
+    ///     record.reference_bases(),
+    ///     &ReferenceBases::try_from(vec![Base::T])?,
+    /// );
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn reference_bases_mut(&mut self) -> &mut ReferenceBases {
+        &mut self.reference_bases
+    }
+
     /// Returns the alternate bases of the record.
     ///
     /// # Examples

--- a/noodles-vcf/src/record.rs
+++ b/noodles-vcf/src/record.rs
@@ -498,6 +498,43 @@ impl Record {
     pub fn genotypes(&self) -> &Genotypes {
         &self.genotypes
     }
+
+    /// Returns a mutable reference to the genotypes of the record.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf::{
+    ///     self as vcf,
+    ///     record::{
+    ///         genotypes::{genotype::{field::{Key, Value}, Field}, Genotype, Genotypes},
+    ///         Position,
+    ///     },
+    /// };
+    ///
+    /// let mut record = vcf::Record::builder()
+    ///     .set_chromosome("sq0".parse()?)
+    ///     .set_position(Position::try_from(1)?)
+    ///     .set_reference_bases("A".parse()?)
+    ///     .build()?;
+    ///
+    /// let keys = "GT:GQ".parse()?;
+    /// let genotypes = Genotypes::new(
+    ///     keys,
+    ///     vec![Genotype::try_from(vec![
+    ///         Field::new(Key::Genotype, Some(Value::String(String::from("0|0")))),
+    ///         Field::new(Key::ConditionalGenotypeQuality, Some(Value::Integer(13))),
+    ///     ])?],
+    /// );
+    ///
+    /// *record.genotypes_mut() = genotypes.clone();
+    ///
+    /// assert_eq!(record.genotypes(), &genotypes);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn genotypes_mut(&mut self) -> &mut Genotypes {
+        &mut self.genotypes
+    }
 }
 
 /// An error returned when the end position is invalid.

--- a/noodles-vcf/src/record.rs
+++ b/noodles-vcf/src/record.rs
@@ -305,6 +305,34 @@ impl Record {
         &self.alternate_bases
     }
 
+    /// Returns a mutable reference to the alternate bases of the record.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf::{
+    ///     self as vcf,
+    ///     record::{alternate_bases::Allele, reference_bases::Base, AlternateBases, Position},
+    /// };
+    ///
+    /// let mut record = vcf::Record::builder()
+    ///     .set_chromosome("sq0".parse()?)
+    ///     .set_position(Position::try_from(1)?)
+    ///     .set_reference_bases("A".parse()?)
+    ///     .build()?;
+    ///
+    /// *record.alternate_bases_mut() = "C".parse()?;
+    ///
+    /// assert_eq!(
+    ///     record.alternate_bases(),
+    ///     &AlternateBases::from(vec![Allele::Bases(vec![Base::C])]),
+    /// );
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn alternate_bases_mut(&mut self) -> &mut AlternateBases {
+        &mut self.alternate_bases
+    }
+
     /// Returns the quality score of the record.
     ///
     /// The quality score is a [Phred quality score].

--- a/noodles-vcf/src/record/alternate_bases.rs
+++ b/noodles-vcf/src/record/alternate_bases.rs
@@ -4,7 +4,11 @@ pub mod allele;
 
 pub use self::allele::Allele;
 
-use std::{error, fmt, ops::Deref, str::FromStr};
+use std::{
+    error, fmt,
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
 use super::MISSING_FIELD;
 
@@ -19,6 +23,12 @@ impl Deref for AlternateBases {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl DerefMut for AlternateBases {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/noodles-vcf/src/record/genotypes.rs
+++ b/noodles-vcf/src/record/genotypes.rs
@@ -38,6 +38,11 @@ impl Genotypes {
         &self.keys
     }
 
+    /// Returns a mutable reference to the genotypes keys.
+    pub fn keys_mut(&mut self) -> &mut Keys {
+        &mut self.keys
+    }
+
     /// Returns the VCF record genotype value.
     pub fn genotypes(
         &self,

--- a/noodles-vcf/src/record/genotypes/genotype.rs
+++ b/noodles-vcf/src/record/genotypes/genotype.rs
@@ -4,7 +4,10 @@ pub mod field;
 
 pub use self::field::Field;
 
-use std::{error, fmt, ops::Deref};
+use std::{
+    error, fmt,
+    ops::{Deref, DerefMut},
+};
 
 use indexmap::IndexMap;
 
@@ -126,6 +129,12 @@ impl Deref for Genotype {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl DerefMut for Genotype {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/noodles-vcf/src/record/genotypes/keys.rs
+++ b/noodles-vcf/src/record/genotypes/keys.rs
@@ -1,6 +1,10 @@
 //! VCF record genotypes keys.
 
-use std::{error, fmt, ops::Deref, str::FromStr};
+use std::{
+    error, fmt,
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
 use indexmap::IndexSet;
 
@@ -25,6 +29,12 @@ impl Deref for Keys {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl DerefMut for Keys {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/noodles-vcf/src/record/reference_bases.rs
+++ b/noodles-vcf/src/record/reference_bases.rs
@@ -4,7 +4,11 @@ pub mod base;
 
 pub use self::base::Base;
 
-use std::{error, fmt, ops::Deref, str::FromStr};
+use std::{
+    error, fmt,
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
 use super::MISSING_FIELD;
 
@@ -17,6 +21,12 @@ impl Deref for ReferenceBases {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl DerefMut for ReferenceBases {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 


### PR DESCRIPTION
I came across a situation where I needed to mutate the genotypes of existing VCF records. As in #65, I figured it'd be good to have `genotypes_mut`. In the process, it seemed natural to also implement `reference_bases_mut` and `alternate_bases_mut` as well as `DerefMut` for `ReferenceBases` and `AlternateBases` to also have mutable access to these parts of the record.

EDIT: Realised mutating the genotypes of an existing record required a bit more than I though. Implemented `DerefMut` for `Genotype` and `Keys` and a mutable getter for `Keys` also. As always, feel free to disregard or request changes as you see fit.