### PR TITLE
vcf/record: Derive PartialOrd/Ord for newtypes

### DIFF
--- a/noodles-vcf/CHANGELOG.md
+++ b/noodles-vcf/CHANGELOG.md
@@ -34,6 +34,8 @@
   
   * vcf/record/position: Derive `PartialOrd` and `Ord`.
 
+  * vcf/record/quality_score: Derive `PartialOrd`.
+
   * vcf/record/reference_bases: Implement `DerefMut` ([#67]).
 
 [#65]: https://github.com/zaeleus/noodles/issues/65

--- a/noodles-vcf/CHANGELOG.md
+++ b/noodles-vcf/CHANGELOG.md
@@ -31,6 +31,8 @@
   * vcf/record/genotypes/genotype: Implement `DerefMut` ([#67]).
 
   * vcf/record/genotypes/keys: Implement `DerefMut` ([#67]).
+  
+  * vcf/record/position: Derive `PartialOrd` and `Ord`.
 
   * vcf/record/reference_bases: Implement `DerefMut` ([#67]).
 

--- a/noodles-vcf/src/record/position.rs
+++ b/noodles-vcf/src/record/position.rs
@@ -5,7 +5,7 @@ use std::{error, fmt, num, str::FromStr};
 const MIN: i32 = 0;
 
 /// A VCF record position.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Position(i32);
 
 impl From<Position> for i32 {

--- a/noodles-vcf/src/record/quality_score.rs
+++ b/noodles-vcf/src/record/quality_score.rs
@@ -7,7 +7,7 @@ use super::value::parse_f32_case_insensitive_extended;
 const MIN: f32 = 0.0;
 
 /// A VCF record quality score.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct QualityScore(f32);
 
 impl fmt::Display for QualityScore {


### PR DESCRIPTION
Just a little ergonomic improvement, adding derives

- `PartialOrd`/`Ord` for `vcf::record::Position`
- `PartialOrd` for `vcf::record::QualityScore`

to avoid having to go in and out of the wrapped type for comparisons.