### PR TITLE
bugfix: resolve conversion from char to us for base

### DIFF
--- a/noodles-sam/src/record/sequence/base.rs
+++ b/noodles-sam/src/record/sequence/base.rs
@@ -86,9 +86,7 @@ impl TryFrom<char> for Base {
     type Error = TryFromCharError;
 
     fn try_from(c: char) -> Result<Self, Self::Error> {
-        u8::try_from(c)
-            .map_err(|_| TryFromCharError(c))
-            .and_then(Self::try_from)
+        Self::try_from(c as u8)
     }
 }
 


### PR DESCRIPTION
I was trying to build from nightly and From<char> is not implement for u8. this is a primative type so you can simply do a straight conversion to u8.

```
error[E0277]: the trait bound `u8: From<char>` is not satisfied
  --> noodles-sam/src/record/sequence/base.rs:89:9
   |
89 |         u8::try_from(c)
   |         ^^^^^^^^^^^^^^^ the trait `From<char>` is not implemented for `u8`
   |
   = help: the following implementations were found:
             <u8 as From<CompressionLevel>>
             <u8 as From<NonZeroU8>>
             <u8 as From<base::Base>>
             <u8 as From<bool>>
           and 4 others
   = note: required because of the requirements on the impl of `Into<u8>` for `char`
   = note: required because of the requirements on the impl of `TryFrom<char>` for `u8`
```