### PR TITLE
Add GZI

### DIFF
--- a/noodles-bgzf/src/gzi.rs
+++ b/noodles-bgzf/src/gzi.rs
@@ -1,5 +1,5 @@
 //! A module for the [GZI Index]. A GZI index contains pairs of compressed and uncompressed offsets
-//! in a BGZF file, where values are stored as little-endian 64-bit unsigned integers.
+//! in a BGZF file. Values in the index are stored as little-endian 64-bit unsigned integers.
 //!
 //! [GZI Index]: http://www.htslib.org/doc/bgzip.html#GZI_FORMAT
 

--- a/noodles-bgzf/src/gzi.rs
+++ b/noodles-bgzf/src/gzi.rs
@@ -2,5 +2,8 @@
 
 mod reader;
 
-/// A GZI Index, representing pairs of compressed and uncompressed offsets in a BGZF file.
-pub type Index = Vec<(u64, u64)>;
+/// A GZI Index containing a number of entries, representing pairs of compressed and uncompressed offsets in a BGZF file.
+pub struct Index {
+  number_entries: u64,
+  offsets: Vec<(u64, u64)>
+}

--- a/noodles-bgzf/src/gzi.rs
+++ b/noodles-bgzf/src/gzi.rs
@@ -1,0 +1,6 @@
+//! GZI index.
+
+mod reader;
+
+/// A GZI Index, representing pairs of compressed and uncompressed offsets in a BGZF file.
+pub type Index = Vec<(u64, u64)>;

--- a/noodles-bgzf/src/gzi.rs
+++ b/noodles-bgzf/src/gzi.rs
@@ -1,10 +1,79 @@
-//! GZI index.
+//! A module for the [GZI Index]. A GZI index contains pairs of compressed and uncompressed offsets
+//! in a BGZF file, where values are stored as little-endian 64-bit unsigned integers.
+//!
+//! [GZI Index]: http://www.htslib.org/doc/bgzip.html#GZI_FORMAT
+
+pub use self::reader::Reader;
 
 mod reader;
 
-/// A GZI Index containing a number of entries, representing pairs of compressed and uncompressed offsets in a BGZF file.
+/// A GZI Index contains a number of entries, representing pairs of compressed and uncompressed
+/// offsets in a BGZF file.
 #[derive(Debug, PartialEq)]
 pub struct Index {
-  number_entries: u64,
-  offsets: Vec<(u64, u64)>
+    number_entries: u64,
+    offsets: Vec<(u64, u64)>,
+}
+
+impl Index {
+    /// Creates a GZI Index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_bgzf::gzi;
+    ///
+    /// let index = gzi::Index::new(vec![(4668, 21294)]);
+    /// ```
+    pub fn new(offsets: Vec<(u64, u64)>) -> Self {
+        Self {
+            number_entries: offsets.len() as u64,
+            offsets,
+        }
+    }
+
+    /// Returns the number of entries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_bgzf::gzi;
+    ///
+    /// let index = gzi::Index::new(vec![(4668, 21294)]);
+    /// assert_eq!(index.number_entries(), 1);
+    /// ```
+    pub fn number_entries(&self) -> u64 {
+        self.number_entries
+    }
+
+    /// Returns the compressed and uncompressed offset pairs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_bgzf::gzi;
+    ///
+    /// let index = gzi::Index::new(vec![(4668, 21294)]);
+    /// assert_eq!(index.offsets(), [(4668, 21294)]);
+    /// ```
+    pub fn offsets(&self) -> &[(u64, u64)] {
+        &self.offsets
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::gzi::Index;
+
+    #[test]
+    fn test_number_entries() {
+        let index = Index::new(vec![(4668, 21294)]);
+        assert_eq!(index.number_entries(), 1);
+    }
+
+    #[test]
+    fn test_offsets() {
+        let index = Index::new(vec![(4668, 21294)]);
+        assert_eq!(index.offsets(), [(4668, 21294)]);
+    }
 }

--- a/noodles-bgzf/src/gzi.rs
+++ b/noodles-bgzf/src/gzi.rs
@@ -1,79 +1,11 @@
-//! A module for the [GZI Index]. A GZI index contains pairs of compressed and uncompressed offsets
-//! in a BGZF file. Values in the index are stored as little-endian 64-bit unsigned integers.
+//! A module for [GZI]. A GZ index contains pairs of compressed and uncompressed offsets in a
+//! BGZF file. Values in the index are stored as little-endian 64-bit unsigned integers.
 //!
-//! [GZI Index]: http://www.htslib.org/doc/bgzip.html#GZI_FORMAT
-
-pub use self::reader::Reader;
+//! [GZI]: http://www.htslib.org/doc/bgzip.html#GZI_FORMAT
 
 mod reader;
 
-/// A GZI Index contains a number of entries, representing pairs of compressed and uncompressed
-/// offsets in a BGZF file.
-#[derive(Debug, PartialEq)]
-pub struct Index {
-    number_entries: u64,
-    offsets: Vec<(u64, u64)>,
-}
+pub use self::reader::Reader;
 
-impl Index {
-    /// Creates a GZI Index.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use noodles_bgzf::gzi;
-    ///
-    /// let index = gzi::Index::new(vec![(4668, 21294)]);
-    /// ```
-    pub fn new(offsets: Vec<(u64, u64)>) -> Self {
-        Self {
-            number_entries: offsets.len() as u64,
-            offsets,
-        }
-    }
-
-    /// Returns the number of entries.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use noodles_bgzf::gzi;
-    ///
-    /// let index = gzi::Index::new(vec![(4668, 21294)]);
-    /// assert_eq!(index.number_entries(), 1);
-    /// ```
-    pub fn number_entries(&self) -> u64 {
-        self.number_entries
-    }
-
-    /// Returns the compressed and uncompressed offset pairs.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use noodles_bgzf::gzi;
-    ///
-    /// let index = gzi::Index::new(vec![(4668, 21294)]);
-    /// assert_eq!(index.offsets(), [(4668, 21294)]);
-    /// ```
-    pub fn offsets(&self) -> &[(u64, u64)] {
-        &self.offsets
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::gzi::Index;
-
-    #[test]
-    fn test_number_entries() {
-        let index = Index::new(vec![(4668, 21294)]);
-        assert_eq!(index.number_entries(), 1);
-    }
-
-    #[test]
-    fn test_offsets() {
-        let index = Index::new(vec![(4668, 21294)]);
-        assert_eq!(index.offsets(), [(4668, 21294)]);
-    }
-}
+/// A GZ Index represents pairs of compressed and uncompressed offsets in a BGZF file.
+pub type Index = Vec<(u64, u64)>;

--- a/noodles-bgzf/src/gzi.rs
+++ b/noodles-bgzf/src/gzi.rs
@@ -1,11 +1,12 @@
-//! A module for [GZI]. A GZ index contains pairs of compressed and uncompressed offsets in a
-//! BGZF file. Values in the index are stored as little-endian 64-bit unsigned integers.
+//! gzip index.
 //!
-//! [GZI]: http://www.htslib.org/doc/bgzip.html#GZI_FORMAT
+//! A [gzip index] (GZI) is a list of compressed and uncompressed offset pairs for a gzipped file.
+//!
+//! [GZ index]: http://www.htslib.org/doc/bgzip.html#GZI_FORMAT
 
 mod reader;
 
 pub use self::reader::Reader;
 
-/// A GZ Index represents pairs of compressed and uncompressed offsets in a BGZF file.
+/// A gzip index.
 pub type Index = Vec<(u64, u64)>;

--- a/noodles-bgzf/src/gzi.rs
+++ b/noodles-bgzf/src/gzi.rs
@@ -3,6 +3,7 @@
 mod reader;
 
 /// A GZI Index containing a number of entries, representing pairs of compressed and uncompressed offsets in a BGZF file.
+#[derive(Debug, PartialEq)]
 pub struct Index {
   number_entries: u64,
   offsets: Vec<(u64, u64)>

--- a/noodles-bgzf/src/gzi/reader.rs
+++ b/noodles-bgzf/src/gzi/reader.rs
@@ -9,7 +9,7 @@ pub struct Reader<R> {
 
 impl<R> Reader<R>
     where
-        R: Read,
+        R: Read
 {
     /// Creates a GZI index reader.
     pub fn new(inner: R) -> Self {
@@ -20,6 +20,29 @@ impl<R> Reader<R>
     ///
     /// The position of the [`Read`](std::io::Read) stream is expected to be at the start.
     pub fn read_index(&mut self) -> io::Result<Index> {
-        todo!()
+        let number_entries = read_little_endian(&mut self.inner)?;
+        let mut offsets = Vec::with_capacity(number_entries as usize);
+
+        for _ in 0..number_entries {
+            let compressed = read_little_endian(&mut self.inner)?;
+            let uncompressed = read_little_endian(&mut self.inner)?;
+            offsets.push((compressed, uncompressed));
+        }
+
+        if self.inner.read(&mut [0; 1])? > 0 {
+            Err(io::Error::new(io::ErrorKind::InvalidData, format!("Trailing data left in read stream, expected {} entries.", number_entries)))
+        } else {
+            Ok(Index { number_entries, offsets })
+        }
     }
+}
+
+/// Reads a little endian u64 from the reader.
+fn read_little_endian<R>(reader: &mut R) -> io::Result<u64>
+    where
+      R: Read
+{
+    let mut buf = [0; 8];
+    reader.read_exact(&mut buf)?;
+    Ok(u64::from_le_bytes(buf))
 }

--- a/noodles-bgzf/src/gzi/reader.rs
+++ b/noodles-bgzf/src/gzi/reader.rs
@@ -33,11 +33,13 @@ where
     /// # Examples
     ///
     /// ```no_run
+    /// # use std::io;
     /// use std::fs::File;
     /// use noodles_bgzf::gzi;
     ///
     /// let mut reader = File::open("sample.gzi").map(gzi::Reader::new)?;
     /// let index = reader.read_index()?;
+    /// # Ok::<(), io::Error>(())
     /// ```
     pub fn read_index(&mut self) -> io::Result<Index> {
         let len = self.inner.read_u64::<LittleEndian>().and_then(|n| {

--- a/noodles-bgzf/src/gzi/reader.rs
+++ b/noodles-bgzf/src/gzi/reader.rs
@@ -30,7 +30,7 @@ impl<R> Reader<R>
         }
 
         if self.inner.read(&mut [0; 1])? > 0 {
-            Err(io::Error::new(io::ErrorKind::InvalidData, format!("Trailing data left in read stream, expected {} entries.", number_entries)))
+            Err(io::Error::new(io::ErrorKind::InvalidData, format!("Trailing data remaining in read stream, expected {} entries.", number_entries)))
         } else {
             Ok(Index { number_entries, offsets })
         }
@@ -45,4 +45,70 @@ fn read_little_endian<R>(reader: &mut R) -> io::Result<u64>
     let mut buf = [0; 8];
     reader.read_exact(&mut buf)?;
     Ok(u64::from_le_bytes(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_index() -> Result<(), Box<dyn std::error::Error>> {
+        let data: &[u8] = &[
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // number_entries = 2
+            0x3c, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // compressed_offset = 4668
+            0x2e, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // uncompressed_offset = 21294
+            0x02, 0x5d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // compressed_offset = 23810
+            0x01, 0x52, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // uncompressed_offset = 86529
+        ];
+
+        let mut reader = Reader::new(data);
+
+        let actual = reader.read_index()?;
+        let expected = Index {
+            number_entries: 2, offsets: vec![(4668, 21294), (23810, 86529)]
+        };
+
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_too_many_entries() -> Result<(), Box<dyn std::error::Error>> {
+        let data: &[u8] = &[
+            0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // number_entries = 3
+            0x3c, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // compressed_offset = 4668
+            0x2e, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // uncompressed_offset = 21294
+            0x02, 0x5d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // compressed_offset = 23810
+            0x01, 0x52, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // uncompressed_offset = 86529
+        ];
+
+        let mut reader = Reader::new(data);
+
+        let actual = reader.read_index().map_err(|err| err.kind());
+        let expected = Err(io::ErrorKind::UnexpectedEof);
+
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_trailing_data() -> Result<(), Box<dyn std::error::Error>> {
+        let data: &[u8] = &[
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // number_entries = 1
+            0x3c, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // compressed_offset = 4668
+            0x2e, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // uncompressed_offset = 21294
+            0x00
+        ];
+
+        let mut reader = Reader::new(data);
+
+        let actual = reader.read_index().map_err(|err| err.kind());
+        let expected = Err(io::ErrorKind::InvalidData);
+
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
 }

--- a/noodles-bgzf/src/gzi/reader.rs
+++ b/noodles-bgzf/src/gzi/reader.rs
@@ -1,24 +1,44 @@
 use std::io;
 use std::io::Read;
+
 use super::Index;
 
-/// A GZI index reader.
+/// A GZI [`Index`](super::Index) reader.
 pub struct Reader<R> {
     inner: R,
 }
 
 impl<R> Reader<R>
-    where
-        R: Read
+where
+    R: Read,
 {
-    /// Creates a GZI index reader.
+    /// Creates a GZI [`Index`](super::Index) reader.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_bgzf::gzi;
+    ///
+    /// let data = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    /// let reader = gzi::Reader::new(&data[..]);
+    /// ```
     pub fn new(inner: R) -> Self {
         Self { inner }
     }
 
-    /// Reads a GZI index.
+    /// Reads a GZI [`Index`](super::Index).
     ///
     /// The position of the [`Read`](std::io::Read) stream is expected to be at the start.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs::File;
+    /// use noodles_bgzf::gzi;
+    ///
+    /// let mut reader = File::open("sample.gzi").map(gzi::Reader::new)?;
+    /// let index = reader.read_index()?;
+    /// ```
     pub fn read_index(&mut self) -> io::Result<Index> {
         let number_entries = read_little_endian(&mut self.inner)?;
         let mut offsets = Vec::with_capacity(number_entries as usize);
@@ -30,17 +50,23 @@ impl<R> Reader<R>
         }
 
         if self.inner.read(&mut [0; 1])? > 0 {
-            Err(io::Error::new(io::ErrorKind::InvalidData, format!("Trailing data remaining in read stream, expected {} entries.", number_entries)))
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Trailing data remaining in read stream, expected {} entries.",
+                    number_entries
+                ),
+            ))
         } else {
-            Ok(Index { number_entries, offsets })
+            Ok(Index::new(offsets))
         }
     }
 }
 
 /// Reads a little endian u64 from the reader.
 fn read_little_endian<R>(reader: &mut R) -> io::Result<u64>
-    where
-      R: Read
+where
+    R: Read,
 {
     let mut buf = [0; 8];
     reader.read_exact(&mut buf)?;
@@ -53,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_read_index() -> Result<(), Box<dyn std::error::Error>> {
-        let data: &[u8] = &[
+        let data = [
             0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // number_entries = 2
             0x3c, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // compressed_offset = 4668
             0x2e, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // uncompressed_offset = 21294
@@ -61,11 +87,29 @@ mod tests {
             0x01, 0x52, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // uncompressed_offset = 86529
         ];
 
-        let mut reader = Reader::new(data);
+        let mut reader = Reader::new(&data[..]);
 
         let actual = reader.read_index()?;
         let expected = Index {
-            number_entries: 2, offsets: vec![(4668, 21294), (23810, 86529)]
+            number_entries: 2,
+            offsets: vec![(4668, 21294), (23810, 86529)],
+        };
+
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_no_entries() -> Result<(), Box<dyn std::error::Error>> {
+        let data = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // number_entries = 0
+
+        let mut reader = Reader::new(&data[..]);
+
+        let actual = reader.read_index()?;
+        let expected = Index {
+            number_entries: 0,
+            offsets: vec![],
         };
 
         assert_eq!(actual, expected);
@@ -75,7 +119,7 @@ mod tests {
 
     #[test]
     fn test_too_many_entries() -> Result<(), Box<dyn std::error::Error>> {
-        let data: &[u8] = &[
+        let data = [
             0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // number_entries = 3
             0x3c, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // compressed_offset = 4668
             0x2e, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // uncompressed_offset = 21294
@@ -83,7 +127,7 @@ mod tests {
             0x01, 0x52, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // uncompressed_offset = 86529
         ];
 
-        let mut reader = Reader::new(data);
+        let mut reader = Reader::new(&data[..]);
 
         let actual = reader.read_index().map_err(|err| err.kind());
         let expected = Err(io::ErrorKind::UnexpectedEof);
@@ -95,14 +139,14 @@ mod tests {
 
     #[test]
     fn test_trailing_data() -> Result<(), Box<dyn std::error::Error>> {
-        let data: &[u8] = &[
+        let data = [
             0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // number_entries = 1
             0x3c, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // compressed_offset = 4668
             0x2e, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // uncompressed_offset = 21294
-            0x00
+            0x00,
         ];
 
-        let mut reader = Reader::new(data);
+        let mut reader = Reader::new(&data[..]);
 
         let actual = reader.read_index().map_err(|err| err.kind());
         let expected = Err(io::ErrorKind::InvalidData);

--- a/noodles-bgzf/src/gzi/reader.rs
+++ b/noodles-bgzf/src/gzi/reader.rs
@@ -1,0 +1,25 @@
+use std::io;
+use std::io::Read;
+use super::Index;
+
+/// A GZI index reader.
+pub struct Reader<R> {
+    inner: R,
+}
+
+impl<R> Reader<R>
+    where
+        R: Read,
+{
+    /// Creates a GZI index reader.
+    pub fn new(inner: R) -> Self {
+        Self { inner }
+    }
+
+    /// Reads a GZI index.
+    ///
+    /// The position of the [`Read`](std::io::Read) stream is expected to be at the start.
+    pub fn read_index(&mut self) -> io::Result<Index> {
+        todo!()
+    }
+}

--- a/noodles-bgzf/src/lib.rs
+++ b/noodles-bgzf/src/lib.rs
@@ -39,10 +39,10 @@ mod r#async;
 
 mod block;
 mod gz;
+pub mod gzi;
 mod reader;
 pub mod virtual_position;
 pub mod writer;
-pub mod gzi;
 
 pub use self::{reader::Reader, virtual_position::VirtualPosition, writer::Writer};
 

--- a/noodles-bgzf/src/lib.rs
+++ b/noodles-bgzf/src/lib.rs
@@ -42,6 +42,7 @@ mod gz;
 mod reader;
 pub mod virtual_position;
 pub mod writer;
+pub mod gzi;
 
 pub use self::{reader::Reader, virtual_position::VirtualPosition, writer::Writer};
 


### PR DESCRIPTION
Closes #103

The following PR implements a GZ Index and Reader for BGZF files.
* Adds a GZI module containing a GZ Index type for pairs of offsets.
* Implements a GZ Index Reader.