### PR TITLE
Implement region query for the reader of bgzipped indexed fasta

### DIFF
--- a/noodles-bam/src/async/reader.rs
+++ b/noodles-bam/src/async/reader.rs
@@ -387,12 +387,12 @@ where
     /// let mut reader = bam::AsyncReader::new(Cursor::new(data));
     ///
     /// let virtual_position = bgzf::VirtualPosition::default();
-    /// reader.seek(virtual_position).await?;
+    /// reader.seek_virtual_position(virtual_position).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn seek(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
-        self.inner.seek(pos).await
+    pub async fn seek_virtual_position(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
+        self.inner.seek_virtual_position(pos).await
     }
 
     /// Returns a stream over records that intersect the given region.

--- a/noodles-bam/src/async/reader/query.rs
+++ b/noodles-bam/src/async/reader/query.rs
@@ -56,7 +56,7 @@ where
                 State::Seek => {
                     ctx.state = match ctx.chunks.next() {
                         Some(chunk) => {
-                            ctx.reader.seek(chunk.start()).await?;
+                            ctx.reader.seek_virtual_position(chunk.start()).await?;
                             State::Read(chunk.end())
                         }
                         None => State::Done,

--- a/noodles-bam/src/reader.rs
+++ b/noodles-bam/src/reader.rs
@@ -344,17 +344,17 @@ where
     /// use noodles_bgzf as bgzf;
     /// let mut reader = bam::Reader::new(Cursor::new(Vec::new()));
     /// let virtual_position = bgzf::VirtualPosition::default();
-    /// reader.seek(virtual_position)?;
+    /// reader.seek_virtual_position(virtual_position)?;
     /// # Ok::<(), io::Error>(())
     /// ```
-    pub fn seek(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
-        self.inner.seek(pos)
+    pub fn seek_virtual_position(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
+        self.inner.seek_virtual_position(pos)
     }
 
     // Seeks to the first record by setting the cursor to the beginning of the stream and
     // (re)reading the header and binary reference sequences.
     fn seek_to_first_record(&mut self) -> io::Result<bgzf::VirtualPosition> {
-        self.seek(bgzf::VirtualPosition::default())?;
+        self.seek_virtual_position(bgzf::VirtualPosition::default())?;
         self.read_header()?;
         self.read_reference_sequences()?;
         Ok(self.virtual_position())
@@ -425,7 +425,7 @@ where
     /// ```
     pub fn query_unmapped(&mut self, index: &bai::Index) -> io::Result<UnmappedRecords<'_, R>> {
         if let Some(pos) = index.first_record_in_last_linear_bin_start_position() {
-            self.seek(pos)?;
+            self.seek_virtual_position(pos)?;
         } else {
             self.seek_to_first_record()?;
         }

--- a/noodles-bam/src/reader/query.rs
+++ b/noodles-bam/src/reader/query.rs
@@ -77,7 +77,7 @@ where
                 State::Seek => {
                     self.state = match self.chunks.next() {
                         Some(chunk) => {
-                            if let Err(e) = self.reader.seek(chunk.start()) {
+                            if let Err(e) = self.reader.seek_virtual_position(chunk.start()) {
                                 return Some(Err(e));
                             }
 

--- a/noodles-bcf/src/async/reader.rs
+++ b/noodles-bcf/src/async/reader.rs
@@ -273,12 +273,12 @@ where
     /// let mut reader = bcf::AsyncReader::new(Cursor::new(data));
     ///
     /// let virtual_position = bgzf::VirtualPosition::default();
-    /// reader.seek(virtual_position).await?;
+    /// reader.seek_virtual_position(virtual_position).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn seek(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
-        self.inner.seek(pos).await
+    pub async fn seek_virtual_position(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
+        self.inner.seek_virtual_position(pos).await
     }
 
     /// Returns a stream over records that intersect the given region.

--- a/noodles-bcf/src/async/reader/query.rs
+++ b/noodles-bcf/src/async/reader/query.rs
@@ -55,7 +55,7 @@ where
                 State::Seek => {
                     ctx.state = match ctx.chunks.next() {
                         Some(chunk) => {
-                            ctx.reader.seek(chunk.start()).await?;
+                            ctx.reader.seek_virtual_position(chunk.start()).await?;
                             State::Read(chunk.end())
                         }
                         None => State::Done,

--- a/noodles-bcf/src/reader.rs
+++ b/noodles-bcf/src/reader.rs
@@ -227,11 +227,11 @@ where
     /// let mut reader = File::open("sample.bcf").map(bcf::Reader::new)?;
     ///
     /// let virtual_position = bgzf::VirtualPosition::from(102334155);
-    /// reader.seek(virtual_position)?;
+    /// reader.seek_virtual_position(virtual_position)?;
     /// # Ok::<(), io::Error>(())
     /// ```
-    pub fn seek(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
-        self.inner.seek(pos)
+    pub fn seek_virtual_position(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
+        self.inner.seek_virtual_position(pos)
     }
 
     /// Returns an iterator over records that intersects the given region.

--- a/noodles-bcf/src/reader/query.rs
+++ b/noodles-bcf/src/reader/query.rs
@@ -78,7 +78,7 @@ where
                 State::Seek => {
                     self.state = match self.chunks.next() {
                         Some(chunk) => {
-                            if let Err(e) = self.reader.seek(chunk.start()) {
+                            if let Err(e) = self.reader.seek_virtual_position(chunk.start()) {
                                 return Some(Err(e));
                             }
 

--- a/noodles-bgzf/src/async/reader.rs
+++ b/noodles-bgzf/src/async/reader.rs
@@ -97,15 +97,15 @@ where
     /// use noodles_bgzf as bgzf;
     /// let mut reader = bgzf::AsyncReader::new(Cursor::new(Vec::new()));
     /// let virtual_position = bgzf::VirtualPosition::from(102334155);
-    /// reader.seek(virtual_position).await?;
+    /// reader.seek_virtual_position(virtual_position).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn seek(&mut self, pos: VirtualPosition) -> io::Result<VirtualPosition> {
+    pub async fn seek_virtual_position(&mut self, pos: VirtualPosition) -> io::Result<VirtualPosition> {
         let stream = self.stream.take().expect("missing stream");
         let mut blocks = stream.into_inner();
 
-        blocks.seek(pos).await?;
+        blocks.seek_virtual_position(pos).await?;
 
         let mut stream = blocks.try_buffered(self.worker_count.get());
 
@@ -188,7 +188,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_seek() -> Result<(), Box<dyn std::error::Error>> {
+    async fn test_seek_virtual_position() -> Result<(), Box<dyn std::error::Error>> {
         #[rustfmt::skip]
         let data = [
             // block 0, udata = b"noodles"
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(reader.virtual_position(), eof);
 
         let position = VirtualPosition::try_from((0, 3))?;
-        reader.seek(position).await?;
+        reader.seek_virtual_position(position).await?;
 
         assert_eq!(reader.virtual_position(), position);
 

--- a/noodles-bgzf/src/async/reader/inflater.rs
+++ b/noodles-bgzf/src/async/reader/inflater.rs
@@ -34,7 +34,7 @@ impl<R> Inflater<R>
 where
     R: AsyncRead + AsyncSeek + Unpin,
 {
-    pub async fn seek(&mut self, pos: VirtualPosition) -> io::Result<VirtualPosition> {
+    pub async fn seek_virtual_position(&mut self, pos: VirtualPosition) -> io::Result<VirtualPosition> {
         let cpos = pos.compressed();
         self.inner.get_mut().seek(SeekFrom::Start(cpos)).await?;
 

--- a/noodles-bgzf/src/reader.rs
+++ b/noodles-bgzf/src/reader.rs
@@ -146,10 +146,10 @@ where
     /// use noodles_bgzf as bgzf;
     /// let mut reader = bgzf::Reader::new(Cursor::new(Vec::new()));
     /// let virtual_position = bgzf::VirtualPosition::from(102334155);
-    /// reader.seek(virtual_position)?;
+    /// reader.seek_virtual_position(virtual_position)?;
     /// # Ok::<(), io::Error>(())
     /// ```
-    pub fn seek(&mut self, pos: VirtualPosition) -> io::Result<VirtualPosition> {
+    pub fn seek_virtual_position(&mut self, pos: VirtualPosition) -> io::Result<VirtualPosition> {
         let (cpos, upos) = pos.into();
 
         self.inner.get_mut().seek(SeekFrom::Start(cpos))?;
@@ -219,7 +219,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_seek() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_seek_virtual_position() -> Result<(), Box<dyn std::error::Error>> {
         #[rustfmt::skip]
         let data = [
             // block 0
@@ -240,7 +240,7 @@ mod tests {
 
         assert_eq!(reader.virtual_position(), eof);
 
-        reader.seek(VirtualPosition::try_from((0, 3))?)?;
+        reader.seek_virtual_position(VirtualPosition::try_from((0, 3))?)?;
 
         buf.clear();
         reader.read_to_end(&mut buf)?;

--- a/noodles-bgzf/src/reader.rs
+++ b/noodles-bgzf/src/reader.rs
@@ -7,7 +7,7 @@ pub use self::builder::Builder;
 
 use std::io::{self, BufRead, Read, Seek, SeekFrom};
 
-use super::{Block, VirtualPosition};
+use super::{gzi, Block, VirtualPosition};
 
 /// A BGZF reader.
 ///
@@ -30,6 +30,8 @@ pub struct Reader<R> {
     inner: block::Inner<R>,
     position: u64,
     block: Block,
+    gzi: Option<gzi::Index>,
+    uncompressed_position: Option<u64>,
 }
 
 impl<R> Reader<R>
@@ -47,6 +49,23 @@ where
     /// ```
     pub fn new(inner: R) -> Self {
         Builder::default().build_from_reader(inner)
+    }
+
+    /// Creates a BGZF reader with GZI.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_bgzf as bgzf;
+    /// let data = [];
+    /// let gzi = vec![];
+    /// let reader = bgzf::Reader::with_gzi(&data[..], gzi);
+    /// ```
+    pub fn with_gzi(inner: R, gzi: gzi::Index) -> Self {
+        let mut reader = Reader::new(inner);
+        reader.gzi = Some(gzi);
+        reader.uncompressed_position = Some(0);
+        reader
     }
 
     /// Returns a reference to the underlying reader.
@@ -105,6 +124,38 @@ where
         self.position
     }
 
+    /// Returns the current uncompressed position of the stream.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_bgzf as bgzf;
+    /// let data = [];
+    /// let reader = bgzf::Reader::new(&data[..]);
+    /// assert_eq!(reader.uncompressed_position(), None);
+    /// let gzi = vec![];
+    /// let reader = bgzf::Reader::with_gzi(&data[..], gzi);
+    /// assert_eq!(reader.uncompressed_position(), Some(0));
+    /// ```
+    pub fn uncompressed_position(&self) -> Option<u64> {
+        self.uncompressed_position
+    }
+
+    /// Returns the current uncompressed position of the stream.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_bgzf as bgzf;
+    /// let data = [];
+    /// let gzi = vec![];
+    /// let reader = bgzf::Reader::with_gzi(&data[..], gzi);
+    /// assert_eq!(reader.get_gzi(), Some(&vec![]));
+    /// ```
+    pub fn get_gzi(&self) -> Option<&gzi::Index> {
+        self.gzi.as_ref()
+    }
+
     /// Returns the current virtual position of the stream.
     ///
     /// # Examples
@@ -159,6 +210,15 @@ where
 
         self.block.data_mut().set_position(usize::from(upos));
 
+        if let Some(gzi) = self.get_gzi() {
+            let gzi = [&[(0, 0)], &gzi[..]].concat();
+            if let Ok(i) = gzi.binary_search_by(|p| p.0.cmp(&cpos)) {
+                self.uncompressed_position = Some(gzi[i].1 + upos as u64);
+            } else {
+                return Err(io::Error::new(io::ErrorKind::Other, "fail to find cpos in gzi"));
+            }
+        }
+
         Ok(pos)
     }
 }
@@ -180,7 +240,15 @@ where
     R: Read,
 {
     fn consume(&mut self, amt: usize) {
-        self.block.data_mut().consume(amt)
+        let prev = self.block.data().position();
+        self.block.data_mut().consume(amt);
+        if let Some(pos) = self.uncompressed_position() {
+            let offset = self.block.data().position() - prev;
+            let pos = pos
+                .checked_add(offset as u64)
+                .expect("overflow when adding offset to uncompressed position");
+            self.uncompressed_position = Some(pos);
+        }
     }
 
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
@@ -189,6 +257,75 @@ where
         }
 
         Ok(self.block.data().as_ref())
+    }
+}
+
+impl<R> Seek for Reader<R>
+where
+    R: Read + Seek,
+{
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        use io::{Error, ErrorKind};
+
+        if let Reader {
+            gzi: Some(gzi),
+            uncompressed_position: Some(cur_upos),
+            ..
+        } = self {
+            let gzi = [&[(0, 0)], &gzi[..]].concat();
+            let cur_upos = *cur_upos;
+            let cur_vpos = self.virtual_position();
+            let mut is_seek_end = false;
+            let new_pos = match pos {
+                SeekFrom::Current(n) => {
+                    if n < 0 {
+                        cur_upos.checked_sub((-n) as u64)
+                    } else {
+                        cur_upos.checked_add(n as u64)
+                    }
+                    .expect("overflow when adding offset to uncompressed position")
+                }
+                SeekFrom::Start(n) => n,
+                SeekFrom::End(n) => {
+                    is_seek_end = true;
+                    let end_cpos = gzi.last().map(|p| p.0).unwrap();
+                    if let Ok(end_pos) = VirtualPosition::try_from((end_cpos, 0)) {
+                        self.seek_virtual_position(end_pos)?;
+                        let end_upos = self.uncompressed_position().unwrap()
+                            + self.block.data().len() as u64;
+                        if n < 0 {
+                            end_upos.checked_sub((-n) as u64)
+                        } else {
+                            end_upos.checked_add(n as u64)
+                        }
+                        .expect("overflow when adding offset to the end of uncompressed position")
+                    } else {
+                        return Err(Error::new(ErrorKind::Other, "fail to convert tuple to VirtualPosition"));
+                    }
+                }
+            };
+            let i = gzi.partition_point(|p| p.1 <= new_pos);
+            let (cpos, gzi_upos) = gzi[i - 1];
+            let upos = new_pos - gzi_upos;
+            if upos > u16::MAX as u64 {
+                if is_seek_end {
+                    self.seek_virtual_position(cur_vpos)?;
+                }
+                return Err(Error::new(ErrorKind::Other, ""))
+            } else {
+                if let Ok(virtual_position) = VirtualPosition::try_from((cpos, upos as u16)) {
+                    self.seek_virtual_position(virtual_position)?;
+                } else {
+                    if is_seek_end {
+                        self.seek_virtual_position(cur_vpos)?;
+                    }
+                    return Err(Error::new(ErrorKind::Other, "fail to convert tuple to VirtualPosition")); 
+                }
+            }
+            Ok(new_pos)
+        } else {
+            return Err(Error::new(ErrorKind::NotFound, "index not found"));
+        }
     }
 }
 
@@ -247,6 +384,54 @@ mod tests {
 
         assert_eq!(buf, b"dles");
         assert_eq!(reader.virtual_position(), eof);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_seek() -> Result<(), Box<dyn std::error::Error>> {
+        #[rustfmt::skip]
+        let data = [
+            // block 0
+            0x1f, 0x8b, 0x08, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x42, 0x43,
+            0x02, 0x00, 0x29, 0x00, 0xb3, 0xcb, 0xcb, 0xcf, 0x4f, 0xc9, 0x49, 0x2d, 0xe6, 0x72,
+            0x0c, 0x71, 0x76, 0xe7, 0x02, 0x00, 0x66, 0x54, 0x8f, 0x56, 0x0e, 0x00, 0x00, 0x00,
+            // EOF block
+            0x1f, 0x8b, 0x08, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x42, 0x43,
+            0x02, 0x00, 0x1b, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let gzi = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+        let mut gzi_reader = gzi::Reader::new(&gzi[..]);
+        let gzi = gzi_reader.read_index()?;
+
+        let eof = 14;
+
+        let mut reader =
+            Reader::with_gzi(Cursor::new(&data), gzi);
+
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf)?;
+
+        assert_eq!(reader.uncompressed_position().unwrap(), eof);
+
+        reader.seek(SeekFrom::Start(1))?;
+
+        let mut line = String::new();
+        reader.read_line(&mut line)?;
+        assert_eq!(line, "noodles\n");
+
+        reader.seek(SeekFrom::End(-13))?;
+        line.clear();
+        reader.read_line(&mut line)?;
+        assert_eq!(line, "noodles\n");
+
+        reader.seek(SeekFrom::Current(2))?;
+        buf.clear();
+        reader.read_to_end(&mut buf)?;
+        assert_eq!(buf, b"CG\n");
+
+        assert_eq!(reader.uncompressed_position().unwrap(), eof);
 
         Ok(())
     }

--- a/noodles-bgzf/src/reader/builder.rs
+++ b/noodles-bgzf/src/reader/builder.rs
@@ -61,6 +61,8 @@ impl Builder {
             inner: block_reader,
             position: 0,
             block: Block::default(),
+            gzi: None,
+            uncompressed_position: None,
         }
     }
 }

--- a/noodles-fasta/examples/bgzipped_indexed_fasta_query.rs
+++ b/noodles-fasta/examples/bgzipped_indexed_fasta_query.rs
@@ -1,0 +1,44 @@
+//! Queries a FASTA with a given reference sequence name.
+//!
+//! The input FASTA must have an index in the same directory.
+//!
+//! The result is similar to the output of `samtools faidx --length 80 <src>
+//! <reference-sequence-name>`.
+
+use std::{
+    env,
+    fs::File,
+    io,
+    path::PathBuf,
+};
+
+use noodles_bgzf as bgzf;
+use noodles_fasta::{self as fasta, fai};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = env::args();
+
+    let src = args.nth(1).map(PathBuf::from).expect("missing src");
+    let raw_region = args.next().expect("missing region");
+
+    let mut gzi_reader = File::open(src.with_extension("gz.gzi"))
+        .map(bgzf::gzi::Reader::new)?;
+    let gzi = gzi_reader.read_index()?;
+
+    let mut reader = File::open(&src)
+        .map(|f| bgzf::Reader::with_gzi(f, gzi))
+        .map(fasta::Reader::new)?;
+
+    let index = fai::read(src.with_extension("gz.fai"))?;
+    let region = raw_region.parse()?;
+
+    let record = reader.query(&index, &region)?;
+
+    let stdout = io::stdout();
+    let handle = stdout.lock();
+    let mut writer = fasta::Writer::new(handle);
+
+    writer.write_record(&record)?;
+
+    Ok(())
+}

--- a/noodles-fasta/src/reader.rs
+++ b/noodles-fasta/src/reader.rs
@@ -240,11 +240,11 @@ where
     ///     .map(fasta::Reader::new)?;
     ///
     /// let virtual_position = bgzf::VirtualPosition::from(102334155);
-    /// reader.seek(virtual_position)?;
+    /// reader.seek_virtual_position(virtual_position)?;
     /// # Ok::<(), io::Error>(())
     /// ```
-    pub fn seek(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
-        self.inner.seek(pos)
+    pub fn seek_virtual_position(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
+        self.inner.seek_virtual_position(pos)
     }
 }
 

--- a/noodles-sam/src/reader.rs
+++ b/noodles-sam/src/reader.rs
@@ -257,11 +257,11 @@ where
     ///     .map(sam::Reader::new)?;
     ///
     /// let virtual_position = bgzf::VirtualPosition::from(102334155);
-    /// reader.seek(virtual_position)?;
+    /// reader.seek_virtual_position(virtual_position)?;
     /// # Ok::<(), io::Error>(())
     /// ```
-    pub fn seek(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
-        self.inner.seek(pos)
+    pub fn seek_virtual_position(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
+        self.inner.seek_virtual_position(pos)
     }
 
     /// Returns an iterator over records that intersect the given region.

--- a/noodles-sam/src/reader/query.rs
+++ b/noodles-sam/src/reader/query.rs
@@ -67,7 +67,7 @@ where
                 State::Seek => {
                     self.state = match self.chunks.next() {
                         Some(chunk) => {
-                            if let Err(e) = self.reader.seek(chunk.start()) {
+                            if let Err(e) = self.reader.seek_virtual_position(chunk.start()) {
                                 return Some(Err(e));
                             }
 

--- a/noodles-vcf/src/async/reader.rs
+++ b/noodles-vcf/src/async/reader.rs
@@ -246,12 +246,12 @@ where
     /// let mut reader = vcf::AsyncReader::new(bgzf::AsyncReader::new(data));
     ///
     /// let virtual_position = bgzf::VirtualPosition::default();
-    /// reader.seek(virtual_position).await?;
+    /// reader.seek_virtual_position(virtual_position).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn seek(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
-        self.inner.seek(pos).await
+    pub async fn seek_virtual_position(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
+        self.inner.seek_virtual_position(pos).await
     }
 
     /// Returns a stream over records that intersects the given region.

--- a/noodles-vcf/src/async/reader/query.rs
+++ b/noodles-vcf/src/async/reader/query.rs
@@ -60,7 +60,7 @@ where
                 State::Seek => {
                     ctx.state = match ctx.chunks.next() {
                         Some(chunk) => {
-                            ctx.reader.seek(chunk.start()).await?;
+                            ctx.reader.seek_virtual_position(chunk.start()).await?;
                             State::Read(chunk.end())
                         }
                         None => State::Done,

--- a/noodles-vcf/src/reader.rs
+++ b/noodles-vcf/src/reader.rs
@@ -254,11 +254,11 @@ where
     /// let mut reader = vcf::Reader::new(bgzf::Reader::new(data));
     ///
     /// let virtual_position = bgzf::VirtualPosition::default();
-    /// reader.seek(virtual_position)?;
+    /// reader.seek_virtual_position(virtual_position)?;
     /// # Ok::<(), io::Error>(())
     /// ```
-    pub fn seek(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
-        self.inner.seek(pos)
+    pub fn seek_virtual_position(&mut self, pos: bgzf::VirtualPosition) -> io::Result<bgzf::VirtualPosition> {
+        self.inner.seek_virtual_position(pos)
     }
 
     /// Returns an iterator over records that intersects the given region.

--- a/noodles-vcf/src/reader/query.rs
+++ b/noodles-vcf/src/reader/query.rs
@@ -86,7 +86,7 @@ where
                 State::Seek => {
                     self.state = match self.chunks.next() {
                         Some(chunk) => {
-                            if let Err(e) = self.reader.seek(chunk.start()) {
+                            if let Err(e) = self.reader.seek_virtual_position(chunk.start()) {
                                 return Some(Err(e));
                             }
 


### PR DESCRIPTION
See #108, the key is to `impl Seek for bgzf::Reader`. My draft implementation has three steps:

1. Rename all `fn seek(&mut self, pos: VirtualPosition)` to `fn seek_virtual_position(&mut self, pos: VirtualPosition)`.
2. `impl Seek for bgzf::Reader`.
* The reader is only seekable when it has the gzi to refer. So I added two fields `gzi: Option<gzi::Index>` and `uncompressed_position: Option<u64>`, to store the index and uncompressed offset, respectively. Plus a help function `bgzf::Reader::with_gzi` to initialize a seekable reader.

* The `uncompressed_position` is relative to the start of the uncompressed **file**, so it should move forward after calling `fn consume`. This field is different from the `upos` in `VirtualPosition` which is relative to the uncompressed data in the **block**. I implemented conversion from `uncompressed_position` to `VirtualPosition` by referring the [answer](https://github.com/samtools/htslib/issues/473#issuecomment-281093049), to make use of the `fn seek_virtual_position` in `fn seek`.
3. Add an example of querying bgzipped indexed fasta file. 

Feel free to modify the added code, or discard the changes.

BTW, thanks for building this fantastic crate.

