### PR TITLE
gff: Formalizes `Comment` and adds `write_comment` method to writer

### DIFF
--- a/noodles-gff/CHANGELOG.md
+++ b/noodles-gff/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+  * gff/writer: Adds `write_line` method to writer.
+
 ## 0.8.0 - 2022-10-20
 
 ### Changed

--- a/noodles-gff/examples/gff_view.rs
+++ b/noodles-gff/examples/gff_view.rs
@@ -13,9 +13,13 @@ fn main() -> io::Result<()> {
 
     let mut reader = File::open(src).map(BufReader::new).map(gff::Reader::new)?;
 
-    for result in reader.records() {
-        let record = result?;
-        println!("{}", record);
+    let stdout = io::stdout();
+    let handle = stdout.lock();
+    let mut writer = gff::Writer::new(handle);
+
+    for result in reader.lines() {
+        let line = result?;
+        writer.write_line(&line)?;
     }
 
     Ok(())

--- a/noodles-gff/examples/gff_write.rs
+++ b/noodles-gff/examples/gff_write.rs
@@ -4,7 +4,7 @@
 
 use std::io;
 
-use noodles_gff as gff;
+use noodles_gff::{self as gff, Line};
 
 fn main() -> io::Result<()> {
     let stdout = io::stdout();
@@ -13,6 +13,9 @@ fn main() -> io::Result<()> {
 
     let version = gff::Directive::GffVersion(Default::default());
     writer.write_directive(&version)?;
+
+    let comment = Line::Comment(String::from("format: gff3"));
+    writer.write_line(&comment)?;
 
     let record = gff::Record::default();
     writer.write_record(&record)?;

--- a/noodles-gff/src/line.rs
+++ b/noodles-gff/src/line.rs
@@ -35,6 +35,16 @@ impl fmt::Display for ParseError {
     }
 }
 
+impl fmt::Display for Line {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Line::Directive(directive) => write!(f, "{}", directive),
+            Line::Comment(comment) => write!(f, "#{}", comment),
+            Line::Record(record) => write!(f, "{}", record),
+        }
+    }
+}
+
 impl FromStr for Line {
     type Err = ParseError;
 

--- a/noodles-gff/src/writer.rs
+++ b/noodles-gff/src/writer.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use super::{Directive, Record};
+use super::{Directive, Line, Record};
 
 /// A GFF writer.
 pub struct Writer<W> {
@@ -34,6 +34,37 @@ where
     /// ```
     pub fn get_ref(&self) -> &W {
         &self.inner
+    }
+
+    /// Writes a [`Line`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io;
+    /// use noodles_gff as gff;
+    /// use gff::line::Line;
+    ///
+    /// let mut writer = gff::Writer::new(Vec::new());
+    ///
+    /// let version = Line::Directive(gff::Directive::GffVersion(Default::default()));
+    /// writer.write_line(&version)?;
+    ///
+    /// let comment = Line::Comment(String::from("noodles"));
+    /// writer.write_line(&comment)?;
+    ///
+    /// let record = Line::Record(gff::Record::default());
+    /// writer.write_line(&record)?;
+    ///
+    /// let expected = b"##gff-version 3
+    /// #noodles
+    /// .\t.\t.\t1\t1\t.\t.\t.\t.
+    /// ";
+    ///
+    /// assert_eq!(&writer.get_ref()[..], &expected[..]);
+    /// # Ok::<(), io::Error>(())
+    pub fn write_line(&mut self, line: &Line) -> io::Result<()> {
+        writeln!(self.inner, "{}", line)
     }
 
     /// Writes a GFF directive.


### PR DESCRIPTION
I suggest we formalize `Comment` as its own type and add the related `write_comment` method to the writer. The argument for the former is one of type specificity being a net positive when available (since this is not really an unconstrained `String`, better to define the parameters within which a comment can exist). The argument for the second is simply that we do not have a method for adding comments to the writer. 

I have also updated the examples:

* `gff_view.rs` has been updated to print all content of the GFF file, not just the records. I have also changed it to use the `gff::Writer` pointed at stdout.
* `gff_write.rs` has been updated to demonstrate how to write a comment.