### PR TITLE
gtf/writer: Adds `write_line` method to writer

### DIFF
--- a/noodles-gtf/CHANGELOG.md
+++ b/noodles-gtf/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+  * gtf/writer: Add line writer (`Writer::write_line`).
+
 ## 0.5.0 - 2022-10-20
 
 ### Changed

--- a/noodles-gtf/src/line.rs
+++ b/noodles-gtf/src/line.rs
@@ -13,6 +13,15 @@ pub enum Line {
     Record(Record),
 }
 
+impl fmt::Display for Line {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Line::Comment(comment) => write!(f, "#{}", comment),
+            Line::Record(record) => write!(f, "{}", record),
+        }
+    }
+}
+
 /// An error returns when a raw GFF line fails to parse.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ParseError {

--- a/noodles-gtf/src/writer.rs
+++ b/noodles-gtf/src/writer.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use super::Record;
+use super::{Line, Record};
 
 /// A GTF writer.
 pub struct Writer<W> {
@@ -63,6 +63,37 @@ where
     /// ```
     pub fn into_inner(self) -> W {
         self.inner
+    }
+
+    /// Writes a [`Line`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io;
+    /// use noodles_gtf as gtf;
+    /// use gtf::line::Line;
+    ///
+    /// let mut writer = gtf::Writer::new(Vec::new());
+    ///
+    /// let version = Line::Comment(String::from("#format: gtf"));
+    /// writer.write_line(&version)?;
+    ///
+    /// let comment = Line::Comment(String::from("noodles"));
+    /// writer.write_line(&comment)?;
+    ///
+    /// let record = Line::Record(gtf::Record::default());
+    /// writer.write_line(&record)?;
+    ///
+    /// let expected = b"##format: gtf
+    /// #noodles
+    /// .\t.\t.\t1\t1\t.\t.\t.\t
+    /// ";
+    ///
+    /// assert_eq!(&writer.get_ref()[..], &expected[..]);
+    /// # Ok::<(), io::Error>(())
+    pub fn write_line(&mut self, line: &Line) -> io::Result<()> {
+        writeln!(self.inner, "{}", line)
     }
 
     /// Writes a GTF record.


### PR DESCRIPTION
Adds a `write_line` method in the same manner as [`noodles/gtf`](https://github.com/zaeleus/noodles/commit/53b43c73e0b904778651bea02a5a529ff209688d).