### PR TITLE
bgzf/reader: Change linear search to binary search

### DIFF
--- a/noodles-bgzf/src/reader.rs
+++ b/noodles-bgzf/src/reader.rs
@@ -181,7 +181,7 @@ where
     ) -> io::Result<u64> {
         assert!(!index.is_empty());
 
-        let i = index.iter().position(|r| r.1 > pos).unwrap_or(index.len());
+        let i = index.partition_point(|r| r.1 <= pos);
         // SAFETY: `i` is > 0.
         let record = index[i - 1];
 


### PR DESCRIPTION
The index is sorted, we could do binary search ([`partition_point`](https://doc.rust-lang.org/core/primitive.slice.html#method.partition_point) method) on it.