### PR TITLE
bgzf/gzi/reader: wrap gzi Reader in a BufReader

### DIFF
--- a/noodles-bgzf/src/gzi.rs
+++ b/noodles-bgzf/src/gzi.rs
@@ -14,8 +14,8 @@ pub use self::reader::Reader;
 #[cfg(feature = "async")]
 pub use self::r#async::Reader as AsyncReader;
 
-use std::{fs::File, io, path::Path};
 pub use std::io::BufReader;
+use std::{fs::File, io, path::Path};
 
 /// A gzip index.
 pub type Index = Vec<(u64, u64)>;
@@ -37,8 +37,6 @@ pub fn read<P>(src: P) -> io::Result<Index>
 where
     P: AsRef<Path>,
 {
-    let mut reader = File::open(src).map(BufReader::new)
-                                    .map(Reader::new)?;
-
+    let mut reader = File::open(src).map(BufReader::new).map(Reader::new)?;
     reader.read_index()
 }

--- a/noodles-bgzf/src/gzi.rs
+++ b/noodles-bgzf/src/gzi.rs
@@ -14,8 +14,11 @@ pub use self::reader::Reader;
 #[cfg(feature = "async")]
 pub use self::r#async::Reader as AsyncReader;
 
-pub use std::io::BufReader;
-use std::{fs::File, io, path::Path};
+use std::{
+    fs::File,
+    io::{self, BufReader},
+    path::Path,
+};
 
 /// A gzip index.
 pub type Index = Vec<(u64, u64)>;

--- a/noodles-bgzf/src/gzi.rs
+++ b/noodles-bgzf/src/gzi.rs
@@ -15,6 +15,7 @@ pub use self::reader::Reader;
 pub use self::r#async::Reader as AsyncReader;
 
 use std::{fs::File, io, path::Path};
+pub use std::io::BufReader;
 
 /// A gzip index.
 pub type Index = Vec<(u64, u64)>;
@@ -36,6 +37,8 @@ pub fn read<P>(src: P) -> io::Result<Index>
 where
     P: AsRef<Path>,
 {
-    let mut reader = File::open(src).map(Reader::new)?;
+    let mut reader = File::open(src).map(BufReader::new)
+                                    .map(Reader::new)?;
+
     reader.read_index()
 }


### PR DESCRIPTION
Fixes #143. 

`strace` is recording 11 read operations now, rather than  9960 - which is more inline with `bgzip`.