### PR TITLE
util: Variant reader

### DIFF
--- a/noodles-bcf/src/reader.rs
+++ b/noodles-bcf/src/reader.rs
@@ -10,7 +10,7 @@ pub use self::{query::Query, records::Records};
 
 use std::{
     ffi::CStr,
-    io::{self, Read, Seek},
+    io::{self, BufRead, Read, Seek},
 };
 
 use byteorder::{LittleEndian, ReadBytesExt};
@@ -292,7 +292,7 @@ impl<R> From<R> for Reader<R> {
 
 impl<R> vcf::VariantReader<R> for Reader<R>
 where
-    R: io::BufRead,
+    R: BufRead,
 {
     fn read_variant_header(&mut self) -> io::Result<vcf::Header> {
         read_magic(&mut self.inner)?;

--- a/noodles-util/CHANGELOG.md
+++ b/noodles-util/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+  * util: Add variant reader (`variant::Reader`).
+
+    This is a high-level reader that abstracts reading both VCF and BCF. It can
+    autodetect the input format and compression type at runtime.
+
 ## 0.4.0 - 2023-02-03
 
 ### Changed

--- a/noodles-util/Cargo.toml
+++ b/noodles-util/Cargo.toml
@@ -18,13 +18,20 @@ alignment = [
   "noodles-fasta",
   "noodles-sam",
 ]
+variant = [
+  "noodles-bcf",
+  "noodles-bgzf",
+  "noodles-vcf",
+]
 
 [dependencies]
 noodles-bam = { path = "../noodles-bam", version = "0.26.0", optional = true }
+noodles-bcf = { path = "../noodles-bcf", version = "0.20.0", optional = true }
 noodles-bgzf = { path = "../noodles-bgzf", version = "0.19.0", optional = true }
 noodles-cram = { path = "../noodles-cram", version = "0.23.0", optional = true }
 noodles-fasta = { path = "../noodles-fasta", version = "0.18.0", optional = true }
 noodles-sam = { path = "../noodles-sam", version = "0.23.0", optional = true }
+noodles-vcf = { path = "../noodles-vcf", version = "0.24.0", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/noodles-util/Cargo.toml
+++ b/noodles-util/Cargo.toml
@@ -43,3 +43,7 @@ required-features = ["alignment"]
 [[example]]
 name = "util_alignment_view"
 required-features = ["alignment"]
+
+[[example]]
+name = "util_variant_view"
+required-features = ["variant"]

--- a/noodles-util/examples/util_variant_view.rs
+++ b/noodles-util/examples/util_variant_view.rs
@@ -1,0 +1,38 @@
+//! Prints a variant file in the VCF format.
+//!
+//! The result matches the output of `bcftools view <src>`.
+
+use std::{
+    env,
+    io::{self, BufWriter},
+};
+
+use noodles_util::variant;
+use noodles_vcf as vcf;
+
+fn main() -> io::Result<()> {
+    let src = env::args().nth(1).expect("missing src");
+
+    let builder = variant::reader::Builder::default();
+
+    let mut reader = if src == "-" {
+        let stdin = io::stdin().lock();
+        builder.build_from_reader(stdin)?
+    } else {
+        builder.build_from_path(src)?
+    };
+
+    let header = reader.read_header()?;
+
+    let stdout = io::stdout().lock();
+    let mut writer = vcf::Writer::new(BufWriter::new(stdout));
+
+    writer.write_header(&header)?;
+
+    for result in reader.records(&header) {
+        let record = result?;
+        writer.write_record(&record)?;
+    }
+
+    Ok(())
+}

--- a/noodles-util/src/lib.rs
+++ b/noodles-util/src/lib.rs
@@ -4,3 +4,6 @@
 
 #[cfg(feature = "alignment")]
 pub mod alignment;
+
+#[cfg(feature = "variant")]
+pub mod variant;

--- a/noodles-util/src/variant.rs
+++ b/noodles-util/src/variant.rs
@@ -1,0 +1,9 @@
+//! I/O for variant formats.
+
+mod format;
+pub mod reader;
+
+pub use self::{
+    format::{Compression, Format},
+    reader::Reader,
+};

--- a/noodles-util/src/variant/format.rs
+++ b/noodles-util/src/variant/format.rs
@@ -12,6 +12,4 @@ pub enum Format {
 pub enum Compression {
     /// BGZF compression.
     Bgzf,
-    /// No compression.
-    Uncompressed,
 }

--- a/noodles-util/src/variant/format.rs
+++ b/noodles-util/src/variant/format.rs
@@ -1,0 +1,17 @@
+/// A variant format.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Format {
+    /// Variant Call Format (VCF).
+    Vcf,
+    /// BCF.
+    Bcf,
+}
+
+/// A variant compression.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Compression {
+    /// BGZF compression.
+    Bgzf,
+    /// No compression.
+    Uncompressed,
+}

--- a/noodles-util/src/variant/reader.rs
+++ b/noodles-util/src/variant/reader.rs
@@ -4,7 +4,7 @@ mod builder;
 
 pub use self::builder::Builder;
 
-use std::io;
+use std::io::{self, BufRead};
 
 use noodles_vcf::{self as vcf, Record, VariantReader};
 
@@ -15,7 +15,7 @@ pub struct Reader<R> {
 
 impl<R> Reader<R>
 where
-    R: io::BufRead,
+    R: BufRead,
 {
     /// Reads and parses a variant header.
     ///

--- a/noodles-util/src/variant/reader/builder.rs
+++ b/noodles-util/src/variant/reader/builder.rs
@@ -1,0 +1,161 @@
+use std::{
+    fs::File,
+    io::{self, BufRead, BufReader, Read},
+    path::Path,
+};
+
+use noodles_bcf as bcf;
+use noodles_bgzf as bgzf;
+use noodles_vcf::{self as vcf, VariantReader};
+
+use crate::variant::{Compression, Format};
+
+use super::Reader;
+
+/// A variant reader builder.
+#[derive(Default)]
+pub struct Builder {
+    compression: Option<Compression>,
+    format: Option<Format>,
+}
+
+impl Builder {
+    /// Sets the compression of the input.
+    ///
+    /// By default, the compression is autodetected on build. This can be used to override it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_util::variant::{self, Compression};
+    /// let builder = variant::reader::Builder::default().set_compression(Compression::Bgzf);
+    /// ```
+    pub fn set_compression(mut self, compression: Compression) -> Self {
+        self.compression = Some(compression);
+        self
+    }
+
+    /// Sets the format of the input.
+    ///
+    /// By default, the format is autodetected on build. This can be used to override it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_util::variant::{self, Format};
+    /// let builder = variant::reader::Builder::default().set_format(Format::Vcf);
+    /// ```
+    pub fn set_format(mut self, format: Format) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Builds a variant reader from a path.
+    ///
+    /// By default, the format and compression will be autodetected. This can be overridden by
+    /// using [`Self::set_format`] and [`Self::set_compression`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use std::io;
+    /// use noodles_util::variant;
+    /// let reader = variant::reader::Builder::default().build_from_path("sample.vcf")?;
+    /// # Ok::<_, io::Error>(())
+    /// ```
+    pub fn build_from_path<P>(self, path: P) -> io::Result<Reader<Box<dyn BufRead>>>
+    where
+        P: AsRef<Path>,
+    {
+        let file = File::open(path)?;
+        self.build_from_reader(file)
+    }
+
+    /// Builds a variant reader from a reader.
+    ///
+    /// By default, the format and compression will be autodetected. This can be overridden by
+    /// using [`Self::set_format`] and [`Self::set_compression`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io;
+    /// use noodles_util::variant;
+    /// let reader = variant::reader::Builder::default().build_from_reader(io::empty())?;
+    /// # Ok::<_, io::Error>(())
+    /// ```
+    pub fn build_from_reader<R>(self, reader: R) -> io::Result<Reader<Box<dyn BufRead>>>
+    where
+        R: Read + 'static,
+    {
+        let mut reader: Box<dyn BufRead> = Box::new(BufReader::new(reader));
+
+        let compression = self
+            .compression
+            .map(Ok)
+            .unwrap_or_else(|| detect_compression(&mut reader))?;
+
+        let format = self
+            .format
+            .map(Ok)
+            .unwrap_or_else(|| detect_format(&mut reader, compression))?;
+
+        let inner: Box<dyn VariantReader<_>> = match (format, compression) {
+            (Format::Vcf, Compression::Uncompressed) => {
+                let inner: Box<dyn BufRead> = Box::new(BufReader::new(reader));
+                Box::new(vcf::Reader::new(inner))
+            }
+            (Format::Vcf, Compression::Bgzf) => {
+                let inner: Box<dyn BufRead> = Box::new(bgzf::Reader::new(reader));
+                Box::new(vcf::Reader::new(inner))
+            }
+            (Format::Bcf, Compression::Uncompressed) => {
+                let inner: Box<dyn BufRead> = Box::new(BufReader::new(reader));
+                Box::new(bcf::Reader::from(inner))
+            }
+            (Format::Bcf, Compression::Bgzf) => {
+                let inner: Box<dyn BufRead> = Box::new(bgzf::Reader::new(reader));
+                Box::new(bcf::Reader::from(inner))
+            }
+        };
+
+        Ok(Reader { inner })
+    }
+}
+
+fn detect_compression<R>(reader: &mut R) -> io::Result<Compression>
+where
+    R: BufRead,
+{
+    const GZIP_MAGIC_NUMBER: [u8; 2] = [0x1f, 0x8b];
+
+    let src = reader.fill_buf()?;
+    if src.get(..2) == Some(&GZIP_MAGIC_NUMBER) {
+        Ok(Compression::Bgzf)
+    } else {
+        Ok(Compression::Uncompressed)
+    }
+}
+
+fn detect_format<R>(reader: &mut R, compression: Compression) -> io::Result<Format>
+where
+    R: BufRead,
+{
+    const BCF_MAGIC_NUMBER: [u8; 3] = *b"BCF";
+
+    let src = reader.fill_buf()?;
+
+    if compression == Compression::Bgzf {
+        let mut reader = bgzf::Reader::new(src);
+        let mut buf = [0; 3];
+        reader.read_exact(&mut buf).ok();
+
+        if buf == BCF_MAGIC_NUMBER {
+            return Ok(Format::Bcf);
+        }
+    } else if src.get(..3) == Some(&BCF_MAGIC_NUMBER) {
+        return Ok(Format::Bcf);
+    }
+
+    Ok(Format::Vcf)
+}

--- a/noodles-vcf/src/lib.rs
+++ b/noodles-vcf/src/lib.rs
@@ -26,9 +26,12 @@ mod r#async;
 pub mod header;
 pub mod reader;
 pub mod record;
+mod variant_reader;
 mod writer;
 
-pub use self::{header::Header, reader::Reader, record::Record, writer::Writer};
+pub use self::{
+    header::Header, reader::Reader, record::Record, variant_reader::VariantReader, writer::Writer,
+};
 
 #[cfg(feature = "async")]
 pub use self::r#async::{Reader as AsyncReader, Writer as AsyncWriter};

--- a/noodles-vcf/src/variant_reader.rs
+++ b/noodles-vcf/src/variant_reader.rs
@@ -1,0 +1,15 @@
+use std::io;
+
+use super::{Header, Record};
+
+/// An variant format reader.
+pub trait VariantReader<R> {
+    /// Reads a VCF header.
+    fn read_variant_header(&mut self) -> io::Result<Header>;
+
+    /// Returns an iterator over records.
+    fn variant_records<'a>(
+        &'a mut self,
+        header: &'a Header,
+    ) -> Box<dyn Iterator<Item = io::Result<Record>> + 'a>;
+}

--- a/noodles-vcf/src/variant_reader.rs
+++ b/noodles-vcf/src/variant_reader.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use super::{Header, Record};
 
-/// An variant format reader.
+/// A variant format reader.
 pub trait VariantReader<R> {
     /// Reads a VCF header.
     fn read_variant_header(&mut self) -> io::Result<Header>;


### PR DESCRIPTION
I needed something like the `noodles_util::alignment` module, but for the common variant call formats (corresponding to the various `--output-type` options  in `bcftools`). I was just playing around to see if this could be easily done in the same spirit as for the alignment module, which seems to be the case.

This PR contains the reader only. If you're happy to accept something like this, I can have a look at the corresponding writer in a follow-up PR (or here, if you prefer). Otherwise, feel free to close and I'll just pull out what I need for private use.