### PR TITLE
util: Variant writer

### DIFF
--- a/noodles-bcf/CHANGELOG.md
+++ b/noodles-bcf/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+  * bcf/writer: Implement `VariantWriter` ([#150]).
+
+[#150]: https://github.com/zaeleus/noodles/issues/150
+
 ### Fixed
 
   * bcf/writer/vcf_record/genotypes: Fix writing dropped values ([#151]).

--- a/noodles-bcf/src/writer.rs
+++ b/noodles-bcf/src/writer.rs
@@ -199,6 +199,26 @@ impl<W> From<W> for Writer<W> {
     }
 }
 
+impl<W> vcf::VariantWriter for Writer<W>
+where
+    W: Write,
+{
+    fn write_variant_header(&mut self, header: &vcf::Header) -> io::Result<()> {
+        write_file_format(&mut self.inner)?;
+        write_header(&mut self.inner, header)
+    }
+
+    fn write_variant_record(
+        &mut self,
+        header: &vcf::Header,
+        record: &vcf::Record,
+    ) -> io::Result<()> {
+        let string_maps = StringMaps::from(header);
+
+        vcf_record::write_vcf_record(&mut self.inner, header, &string_maps, record)
+    }
+}
+
 fn write_file_format<W>(writer: &mut W) -> io::Result<()>
 where
     W: Write,

--- a/noodles-util/CHANGELOG.md
+++ b/noodles-util/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+  * util: Add variant writer (`variant::Writer`) ([#150]).
+
+    This is a high-level writer that abstracts writing both VCF and BCF. It can
+    autodetect the input format and compression type at runtime.
+
+[#150]: https://github.com/zaeleus/noodles/issues/150
+
 ## 0.5.0 - 2023-03-03
 
 ### Added

--- a/noodles-util/CHANGELOG.md
+++ b/noodles-util/CHANGELOG.md
@@ -7,7 +7,7 @@
   * util: Add variant writer (`variant::Writer`) ([#150]).
 
     This is a high-level writer that abstracts writing both VCF and BCF. It can
-    autodetect the input format and compression type at runtime.
+    autodetect the output format and compression type at runtime.
 
 [#150]: https://github.com/zaeleus/noodles/issues/150
 

--- a/noodles-util/Cargo.toml
+++ b/noodles-util/Cargo.toml
@@ -45,9 +45,9 @@ name = "util_alignment_view"
 required-features = ["alignment"]
 
 [[example]]
-name = "util_variant_view"
+name = "util_variant_rewrite"
 required-features = ["variant"]
 
 [[example]]
-name = "util_variant_rewrite"
+name = "util_variant_view"
 required-features = ["variant"]

--- a/noodles-util/Cargo.toml
+++ b/noodles-util/Cargo.toml
@@ -47,3 +47,7 @@ required-features = ["alignment"]
 [[example]]
 name = "util_variant_view"
 required-features = ["variant"]
+
+[[example]]
+name = "util_variant_rewrite"
+required-features = ["variant"]

--- a/noodles-util/examples/util_variant_rewrite.rs
+++ b/noodles-util/examples/util_variant_rewrite.rs
@@ -1,0 +1,29 @@
+//! Rewrites a variant format to another variant format.
+//!
+//! The output format is determined from the extension of the destination.
+
+use std::{env, io};
+
+use noodles_util::variant;
+
+fn main() -> io::Result<()> {
+    let mut args = env::args().skip(1);
+
+    let src = args.next().expect("missing src");
+    let dst = args.next().expect("missing dst");
+
+    let mut reader = variant::reader::Builder::default().build_from_path(src)?;
+
+    let header = reader.read_header()?;
+
+    let mut writer = variant::writer::Builder::default().build_from_path(dst)?;
+
+    writer.write_header(&header)?;
+
+    for result in reader.records(&header) {
+        let record = result?;
+        writer.write_record(&header, &record)?;
+    }
+
+    Ok(())
+}

--- a/noodles-util/src/variant.rs
+++ b/noodles-util/src/variant.rs
@@ -2,8 +2,10 @@
 
 mod format;
 pub mod reader;
+pub mod writer;
 
 pub use self::{
     format::{Compression, Format},
     reader::Reader,
+    writer::Writer,
 };

--- a/noodles-util/src/variant/writer.rs
+++ b/noodles-util/src/variant/writer.rs
@@ -1,0 +1,64 @@
+//! Variant writer.
+
+mod builder;
+
+pub use self::builder::Builder;
+
+use std::io;
+
+use noodles_vcf as vcf;
+
+/// A variant writer.
+pub struct Writer {
+    inner: Box<dyn vcf::VariantWriter>,
+}
+
+impl Writer {
+    /// Writes a VCF header.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io;
+    /// use noodles_vcf as vcf;
+    /// use noodles_util::variant::{self, Compression, Format};
+    ///
+    /// let mut writer = variant::writer::Builder::default()
+    ///     .set_format(Format::Bcf)
+    ///     .set_compression(Some(Compression::Bgzf))
+    ///     .build_from_writer(io::sink());
+    ///
+    /// let header = vcf::Header::default();
+    /// writer.write_header(&header)?;
+    /// # Ok::<_, io::Error>(())
+    /// ```
+    pub fn write_header(&mut self, header: &vcf::Header) -> io::Result<()> {
+        self.inner.write_variant_header(header)
+    }
+
+    /// Writes a variant record.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io;
+    /// use noodles_vcf::{self as vcf, Record};
+    /// use noodles_util::variant::{self, Format};
+    ///
+    /// let mut writer = variant::writer::Builder::default()
+    ///     .set_format(Format::Vcf)
+    ///     .set_compression(None)
+    ///     .build_from_writer(io::sink());
+    ///
+    /// let header = vcf::Header::default();
+    /// writer.write_header(&header)?;
+    ///
+    /// let s = "sq0\t8\t.\tA\t.\t.\tPASS\t.";
+    /// let record = Record::try_from_str(s, &header)?;
+    /// writer.write_record(&header, &record)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn write_record(&mut self, header: &vcf::Header, record: &vcf::Record) -> io::Result<()> {
+        self.inner.write_variant_record(header, record)
+    }
+}

--- a/noodles-util/src/variant/writer/builder.rs
+++ b/noodles-util/src/variant/writer/builder.rs
@@ -1,0 +1,186 @@
+use std::{
+    fs::File,
+    io::{self, Write},
+    path::Path,
+};
+
+use noodles_bcf as bcf;
+use noodles_bgzf as bgzf;
+use noodles_vcf as vcf;
+
+use crate::variant::{Compression, Format};
+
+use super::Writer;
+
+/// A variant writer builder.
+#[derive(Default)]
+pub struct Builder {
+    // None means infer on build; Some(None) means no compression explicitly set.
+    compression: Option<Option<Compression>>,
+    format: Option<Format>,
+}
+
+impl Builder {
+    /// Sets the compression of the output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_util::variant::{self, Compression};
+    /// let builder = variant::writer::Builder::default().set_compression(Some(Compression::Bgzf));
+    /// ```
+    pub fn set_compression(mut self, compression: Option<Compression>) -> Self {
+        self.compression = Some(compression);
+        self
+    }
+
+    /// Sets the format of the output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_util::variant::{self, Format};
+    /// let builder = variant::writer::Builder::default().set_format(Format::Vcf);
+    /// ```
+    pub fn set_format(mut self, format: Format) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Builds a variant writer from a path.
+    ///
+    /// If the format or compression is not set, it is detected from the path extension.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use std::io;
+    /// use noodles_util::variant::{self, Compression, Format};
+    ///
+    /// let writer = variant::writer::Builder::default()
+    ///     .set_format(Format::Vcf)
+    ///     .set_compression(Some(Compression::Bgzf))
+    ///     .build_from_path("out.vcf.gz")?;
+    /// # Ok::<_, io::Error>(())
+    /// ```
+    pub fn build_from_path<P>(mut self, src: P) -> io::Result<Writer>
+    where
+        P: AsRef<Path>,
+    {
+        let src = src.as_ref();
+
+        let compression = self
+            .compression
+            .get_or_insert_with(|| detect_compression_from_path_extension(src));
+
+        if self.format.is_none() {
+            self.format = detect_format_from_path_extension(src, *compression);
+        }
+
+        let file = File::create(src)?;
+        Ok(self.build_from_writer(file))
+    }
+
+    /// Builds a variant writer from a writer.
+    ///
+    /// If the format is not set, VCF format is used. If the compression is not set, no compression
+    /// is used.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io;
+    /// use noodles_util::variant::{self, Compression, Format};
+    ///
+    /// let writer = variant::writer::Builder::default()
+    ///     .set_format(Format::Vcf)
+    ///     .set_compression(Some(Compression::Bgzf))
+    ///     .build_from_writer(io::sink());
+    /// ```
+    pub fn build_from_writer<W>(self, writer: W) -> Writer
+    where
+        W: Write + 'static,
+    {
+        let format = self.format.unwrap_or(Format::Vcf);
+        let compression = self.compression.unwrap_or(None);
+
+        let inner: Box<dyn vcf::VariantWriter> = match (format, compression) {
+            (Format::Vcf, None) => Box::new(vcf::Writer::new(writer)),
+            (Format::Vcf, Some(Compression::Bgzf)) => {
+                Box::new(vcf::Writer::new(bgzf::Writer::new(writer)))
+            }
+            (Format::Bcf, None) => Box::new(bcf::Writer::from(
+                bgzf::writer::Builder::default()
+                    .set_compression_level(bgzf::writer::CompressionLevel::none())
+                    .build_with_writer(writer),
+            )),
+            (Format::Bcf, Some(Compression::Bgzf)) => Box::new(bcf::Writer::new(writer)),
+        };
+
+        Writer { inner }
+    }
+}
+
+fn detect_format_from_path_extension<P>(path: P, compression: Option<Compression>) -> Option<Format>
+where
+    P: AsRef<Path>,
+{
+    let path = path.as_ref();
+
+    match (compression, path.extension().and_then(|ext| ext.to_str())) {
+        (None, Some("vcf")) => Some(Format::Vcf),
+        (None, Some("bcf")) => Some(Format::Bcf),
+        (Some(Compression::Bgzf), Some("gz") | Some("bgz")) => {
+            detect_format_from_path_extension(path.file_stem()?, None)
+        }
+        _ => None,
+    }
+}
+
+fn detect_compression_from_path_extension<P>(path: P) -> Option<Compression>
+where
+    P: AsRef<Path>,
+{
+    match path.as_ref().extension().and_then(|ext| ext.to_str()) {
+        Some("gz") | Some("bgz") => Some(Compression::Bgzf),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_compression_from_path_extension() {
+        assert_eq!(detect_compression_from_path_extension("out.vcf"), None);
+        assert_eq!(
+            detect_compression_from_path_extension("out.vcf.gz"),
+            Some(Compression::Bgzf),
+        );
+    }
+
+    #[test]
+    fn test_detect_format_from_path_extension() {
+        assert_eq!(
+            detect_format_from_path_extension("out.vcf", None),
+            Some(Format::Vcf)
+        );
+        assert_eq!(
+            detect_format_from_path_extension("out.vcf.gz", Some(Compression::Bgzf)),
+            Some(Format::Vcf)
+        );
+        assert_eq!(
+            detect_format_from_path_extension("out.bcf", None),
+            Some(Format::Bcf)
+        );
+        assert_eq!(
+            detect_format_from_path_extension("out.bcf.bgz", Some(Compression::Bgzf)),
+            Some(Format::Bcf)
+        );
+
+        assert_eq!(detect_format_from_path_extension("out.vcf.gz", None), None);
+
+        assert!(detect_format_from_path_extension("out.fa", None).is_none());
+    }
+}

--- a/noodles-vcf/CHANGELOG.md
+++ b/noodles-vcf/CHANGELOG.md
@@ -16,6 +16,8 @@
 
     This is a generalization for writing VCF-like variant formats.
 
+  * vcf/writer: Implement `VariantWriter` ([#150]).
+
 [#150]: https://github.com/zaeleus/noodles/issues/150
 
 ### Changed

--- a/noodles-vcf/CHANGELOG.md
+++ b/noodles-vcf/CHANGELOG.md
@@ -12,6 +12,12 @@
     (`Builder::build_from_path`), which can open raw VCF files (`*.vcf`)
     and bgzipped VCF (`*.vcf.gz`) files.
 
+  * vcf: Add a variant writer trait (`VariantWriter`) ([#150]).
+
+    This is a generalization for writing VCF-like variant formats.
+
+[#150]: https://github.com/zaeleus/noodles/issues/150
+
 ### Changed
 
   * vcf/record/alternate_bases: Move missing field value parsing to record

--- a/noodles-vcf/src/lib.rs
+++ b/noodles-vcf/src/lib.rs
@@ -28,11 +28,12 @@ pub mod indexed_reader;
 pub mod reader;
 pub mod record;
 mod variant_reader;
+mod variant_writer;
 mod writer;
 
 pub use self::{
     header::Header, indexed_reader::IndexedReader, reader::Reader, record::Record,
-    variant_reader::VariantReader, writer::Writer,
+    variant_reader::VariantReader, variant_writer::VariantWriter, writer::Writer,
 };
 
 #[cfg(feature = "async")]

--- a/noodles-vcf/src/variant_writer.rs
+++ b/noodles-vcf/src/variant_writer.rs
@@ -1,0 +1,12 @@
+use std::io;
+
+use super::{Header, Record};
+
+/// A variant format writer.
+pub trait VariantWriter {
+    /// Writes a VCF header.
+    fn write_variant_header(&mut self, header: &Header) -> io::Result<()>;
+
+    /// Writes a variant record.
+    fn write_variant_record(&mut self, header: &Header, record: &Record) -> io::Result<()>;
+}

--- a/noodles-vcf/src/writer.rs
+++ b/noodles-vcf/src/writer.rs
@@ -3,7 +3,7 @@ mod record;
 use std::io::{self, Write};
 
 use self::record::write_record;
-use super::{Header, Record};
+use super::{Header, Record, VariantWriter};
 
 /// A VCF writer.
 ///
@@ -139,6 +139,19 @@ where
     /// ```
     pub fn write_record(&mut self, record: &Record) -> io::Result<()> {
         write_record(&mut self.inner, record)
+    }
+}
+
+impl<W> VariantWriter for Writer<W>
+where
+    W: Write,
+{
+    fn write_variant_header(&mut self, header: &Header) -> io::Result<()> {
+        self.write_header(header)
+    }
+
+    fn write_variant_record(&mut self, _: &Header, record: &Record) -> io::Result<()> {
+        self.write_record(record)
     }
 }
 


### PR DESCRIPTION
Closes #150 

The followup to #149, adding the `VariantWriter` trait in `noodles-vcf` and the `variant::Writer` in `noodles-util`.

As agreed in #150, I've left aside the issue of `StringMaps` in the impl for `VariantWriter` for now.

Mostly, this follows the implementation of `AlignmentWriter` and `alignment::Writer`, but I had to make a few choices about the compression behaviour for the BCF format that may warrant a bit of attention. Specifically,
- Specifying `None` for compression for BCF leads to a BGZF-compressed file using compression level 0.
- The default compression for BCF (and VCF) is `None`.
- The path extension `.bcf` leads to `None` for compression, unlike `.bcf.(gz|bgz)`.
As you mentioned in the previous PR, BCF should technically always be compressed, so I see how this could be debatable. Let me know if you have different preferences.