### PR TITLE
Update Cargo.toml

### DIFF
--- a/noodles-cram/Cargo.toml
+++ b/noodles-cram/Cargo.toml
@@ -18,7 +18,7 @@ libdeflate = ["dep:libdeflater"]
 bitflags.workspace = true
 byteorder.workspace = true
 bytes.workspace = true
-bzip2 = "0.4.1"
+bzip2 = "0.4.4"
 flate2.workspace = true
 md-5 = "0.10.0"
 noodles-bam = { path = "../noodles-bam", version = "0.34.0" }


### PR DESCRIPTION
Updates bzip dependency to the patch version of 0.4.4

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0004.html)
[fix](https://github.com/alexcrichton/bzip2-rs/pull/86)