### PR TITLE
[bam] makes sequence writer no-op for empty sequence.

### DIFF
--- a/noodles-bam/CHANGELOG.md
+++ b/noodles-bam/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+  * bam/record/codec/encoder/sequence: Fix writing an empty sequence when the
+    read length is nonempty ([#176]).
+
+[#176]: https://github.com/zaeleus/noodles/issues/176
+
 ## 0.35.0 - 2023-06-08
 
 ### Removed

--- a/noodles-bam/src/record/codec/encoder/sequence.rs
+++ b/noodles-bam/src/record/codec/encoder/sequence.rs
@@ -7,6 +7,10 @@ pub fn put_sequence<B>(dst: &mut B, read_length: usize, sequence: &Sequence) -> 
 where
     B: BufMut,
 {
+    if sequence.is_empty() {
+        return Ok(());
+    }
+
     // § 1.4.10 "`SEQ`" (2022-08-22): "If not a '*', the length of the sequence must equal the sum
     // of lengths of `M`/`I`/`S`/`=`/`X` operations in `CIGAR`."
     if read_length > 0 && sequence.len() != read_length {

--- a/noodles-bam/src/record/codec/encoder/sequence.rs
+++ b/noodles-bam/src/record/codec/encoder/sequence.rs
@@ -80,6 +80,10 @@ mod tests {
         t(&mut buf, &"ACGT".parse()?, &[0x12, 0x48])?;
 
         buf.clear();
+        put_sequence(&mut buf, 2, &Sequence::default())?;
+        assert!(buf.is_empty());
+
+        buf.clear();
         let sequence = "A".parse()?;
         assert!(matches!(
             put_sequence(&mut buf, 2, &sequence),


### PR DESCRIPTION
Fixes #176 .  