### PR TITLE
refget: Allow metadata/md5 to be optional

### DIFF
--- a/noodles-refget/src/sequence/metadata.rs
+++ b/noodles-refget/src/sequence/metadata.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 /// Sequence metadata.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct Metadata {
-    md5: String,
+    md5: Option<String>,
     trunc512: Option<String>,
     length: u32,
     aliases: Vec<Alias>,
@@ -17,8 +17,8 @@ pub struct Metadata {
 
 impl Metadata {
     /// Returns the MD5 digest in hexadecimal.
-    pub fn md5(&self) -> &str {
-        &self.md5
+    pub fn md5(&self) -> Option<&str> {
+        self.md5.as_deref()
     }
 
     /// Returns the TRUNC512 digest in hexadecimal.


### PR DESCRIPTION
This change allows the `md5` response in the refget metadata to be optional, in line with `trunc512`.

It is unfortunately a bit vaguely phrased in the refget specs. While it isn't explicitly stated in the response description that this field can be null, the important bit is:

> The supported checksum algorithms are MD5 (a 32 character HEX string) and a SHA-512 based system called TRUNC512 (a 48 character HEX string, see later for details). Servers MUST support sequence retrieval by one or more of these algorithms, and are encouraged to support all to maximize interoperability.

In summary, there is no need for the server to support md5, as long as it supports other options. While unlikely to see this often in the wild, I would suggest staying on the safe side and don't assume that md5 must be set.

See also the discussion in [https://github.com/samtools/hts-specs/pull/479](https://github.com/samtools/hts-specs/pull/479/files/36402266e7875c35109f74eb64e86c62fb600ae8#diff-6d0ee984bc484773c3af9e49b390168a371979e396e2de4887bff1ee1791c3ae).