### PR TITLE
refget: Update to v2.0.0 specifications

### DIFF
--- a/noodles-refget/src/sequence/metadata.rs
+++ b/noodles-refget/src/sequence/metadata.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct Metadata {
     md5: String,
-    trunc512: Option<String>,
+    ga4gh: Option<String>,
     length: u32,
     aliases: Vec<Alias>,
 }
@@ -21,9 +21,9 @@ impl Metadata {
         &self.md5
     }
 
-    /// Returns the TRUNC512 digest in hexadecimal.
-    pub fn trunc512(&self) -> Option<&str> {
-        self.trunc512.as_deref()
+    /// Returns the ga4gh digest in hexadecimal.
+    pub fn ga4gh(&self) -> Option<&str> {
+        self.ga4gh.as_deref()
     }
 
     /// Returns the length.

--- a/noodles-refget/src/sequence/service.rs
+++ b/noodles-refget/src/sequence/service.rs
@@ -9,8 +9,8 @@ use serde::Deserialize;
 pub struct Service {
     circular_supported: bool,
     algorithms: Vec<String>,
+    identifier_types: Vec<String>,
     subsequence_limit: Option<u32>,
-    supported_api_version: Vec<String>,
 }
 
 impl Service {
@@ -24,15 +24,15 @@ impl Service {
         &self.algorithms
     }
 
-    /// Returns the maximum length of an interval.
-    ///
-    /// If missing, there is no limit.
-    pub fn subsequence_limit(&self) -> Option<u32> {
-        self.subsequence_limit
+    /// Returns a list of supported sequence type identifiers.
+    pub fn identifier_types(&self) -> &[String] {
+        &self.identifier_types
     }
 
-    /// Returns a list of supported refget versions.
-    pub fn supported_api_versions(&self) -> &[String] {
-        &self.supported_api_version
+    /// Returns the maximum length of an interval.
+    ///
+    /// If missing or smaller than 1, there is no limit.
+    pub fn subsequence_limit(&self) -> Option<u32> {
+        self.subsequence_limit
     }
 }

--- a/noodles-refget/src/sequence/service/builder.rs
+++ b/noodles-refget/src/sequence/service/builder.rs
@@ -32,12 +32,12 @@ impl Builder {
         response
             .json()
             .await
-            .map(|data: ServiceInfoResponse| data.service)
+            .map(|data: ServiceInfoResponse| data.refget)
             .map_err(Error::Request)
     }
 }
 
 #[derive(Deserialize)]
 struct ServiceInfoResponse {
-    service: Service,
+    refget: Service,
 }


### PR DESCRIPTION
This PR addresses #185 and implements the minimal set of changes for updating the refget client to the current v2 refget specs.

The version number has been updated to `v0.2.0` to reflect the breaking changes.

The dependencies of the crate have also been updated - however, this is fully optional.

Any comments are welcome.