### PR TITLE
vcf/header/parser: Allow for v4.2 PEDIGREE format fields

### DIFF
--- a/noodles-vcf/src/header/parser.rs
+++ b/noodles-vcf/src/header/parser.rs
@@ -310,6 +310,40 @@ mod tests {
     }
 
     #[test]
+    fn test_from_str_with_v42_pedigree() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::{
+            header::record::{
+                value::{
+                    map::{Other},
+                    Map,
+                },
+                Value,
+            },
+        };
+        let s = r#"##fileformat=VCFv4.2
+##PEDIGREE=<Child=A,Mother=B,Father=C>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample0
+"#;
+        let actual = Parser::default().parse(s)?;
+        let expected = Header::builder()
+            .set_file_format(FileFormat::new(4, 2))
+            .insert(
+                "PEDIGREE".parse()?,
+                Value::Map(
+                    String::from("A"),
+                    Map::<Other>::builder()
+                        .insert("Father".parse()?, "C")
+                        .insert("Mother".parse()?, "B")
+                        .build()?,
+                ),
+            )?
+            .add_sample_name("sample0")
+            .build();
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
     fn test_from_str_without_file_format() {
         let s = r#"##ALT=<ID=DEL,Description="Deletion">
 "#;

--- a/noodles-vcf/src/header/parser/record/value/map/other.rs
+++ b/noodles-vcf/src/header/parser/record/value/map/other.rs
@@ -109,6 +109,12 @@ pub fn parse_other(src: &mut &[u8]) -> Result<(String, Map<Other>), ParseError> 
     super::consume_suffix(src)
         .map_err(|e| ParseError::new(id.clone(), ParseErrorKind::InvalidMap(e)))?;
 
+    if id.is_none() {
+        if let Some((_, v)) = other_fields.shift_remove_index(0) {
+            id = Some(v.to_string());
+        }
+    }
+
     let id = id.ok_or_else(|| ParseError::new(None, ParseErrorKind::MissingId))?;
 
     Ok((


### PR DESCRIPTION
This solves #201.

The fix is a bit too general, as this would also allow other OTHER fields to silently pass without error, but given the inconsistencies of `vcf` formats, this might be more in line with other vcf processing tools.

We can also narrow this behavior to PEDIGREE, but this would require more complexity than what I added here.

Edits much appreciated, I'm not really experienced in Rust