### PR TITLE
Add reserve method to Cigar for use in `get_cigar`

### DIFF
--- a/noodles-bam/src/record/codec/decoder/cigar.rs
+++ b/noodles-bam/src/record/codec/decoder/cigar.rs
@@ -60,6 +60,7 @@ where
     }
 
     cigar.clear();
+    cigar.reserve(n_cigar_op);
 
     for _ in 0..n_cigar_op {
         let op = decode_op(src.get_u32_le()).map_err(DecodeError::InvalidOp)?;

--- a/noodles-sam/src/record/cigar.rs
+++ b/noodles-sam/src/record/cigar.rs
@@ -35,7 +35,7 @@ impl Cigar {
     /// # Examples
     ///
     /// ```no_run
-    /// use noodles_sam::record::{cigar::{op::Kind, Op}, Cigar};
+    /// use noodles_sam::record::Cigar;
     ///
     /// let mut cigar: Cigar = Cigar::default();
     /// cigar.reserve(1);

--- a/noodles-sam/src/record/cigar.rs
+++ b/noodles-sam/src/record/cigar.rs
@@ -30,6 +30,20 @@ impl Cigar {
         self.0.clear();
     }
 
+    /// Reserves capacity for additional operations.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use noodles_sam::record::{cigar::{op::Kind, Op}, Cigar};
+    ///
+    /// let mut cigar: Cigar = Cigar::default();
+    /// cigar.reserve(1);
+    /// ```
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional)
+    }
+
     /// Calculates the alignment span over the reference sequence.
     ///
     /// This sums the lengths of the CIGAR operations that consume the reference sequence, i.e.,


### PR DESCRIPTION
Hi,

I'd like to propose a PR that I think could improve BAM cigar parsing performance. I noticed while profiling a tool of mine that calls to `get_cigar` may have do n allocations based on the number of cigar ops. Looking at the `get_cigar` function, it already takes the number of ops, so this PR adds a `reserve` method on `Cigar` so that `get_cigar` can make use of it.

I did a little benchmark via criterion that seems to indicate reduced runtime and reduced runtime variance.

<img width="1584" alt="image" src="https://github.com/zaeleus/noodles/assets/421839/b239cd89-5a20-4bf5-b20f-965dd3c4517d">

I put the benchmark code in a separate branch here: https://github.com/tshauck/noodles/tree/add-reserve-to-cigar-decode-benches/target/criterion (with some changes to `noodles-bam` too).