### PR TITLE
fix: lazy vcf overreading into next record

### DIFF
--- a/noodles-vcf/CHANGELOG.md
+++ b/noodles-vcf/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Fixed
 
-  * vcf/lazy/record/bounds: Fix range for info field ([#224]).
+  * vcf/lazy/record/bounds: Fix range for info field ([#223]).
 
+  * vcf/reader/lazy_record: Disallow newlines to appear in fields ([#224]).
+
+[#223]: https://github.com/zaeleus/noodles/pull/223
 [#224]: https://github.com/zaeleus/noodles/pull/224
 
 ## 0.48.0 - 2023-12-14

--- a/noodles-vcf/src/reader.rs
+++ b/noodles-vcf/src/reader.rs
@@ -2,14 +2,15 @@
 
 mod builder;
 mod header;
+mod lazy_record;
 pub(crate) mod query;
 pub mod record;
 mod records;
 
-use crate::lazy;
-
+use self::lazy_record::read_lazy_record;
 pub(crate) use self::record::parse_record;
 pub use self::{builder::Builder, query::Query, records::Records};
+use crate::lazy;
 
 use std::{
     io::{self, BufRead, Read, Seek},
@@ -392,78 +393,6 @@ where
     }
 }
 
-fn read_lazy_record<R>(reader: &mut R, record: &mut lazy::Record) -> io::Result<usize>
-where
-    R: BufRead,
-{
-    record.buf.clear();
-
-    let mut len = 0;
-
-    len += read_field(reader, &mut record.buf)?;
-    record.bounds.chromosome_end = record.buf.len();
-
-    len += read_field(reader, &mut record.buf)?;
-    record.bounds.position_end = record.buf.len();
-
-    len += read_field(reader, &mut record.buf)?;
-    record.bounds.ids_end = record.buf.len();
-
-    len += read_field(reader, &mut record.buf)?;
-    record.bounds.reference_bases_end = record.buf.len();
-
-    len += read_field(reader, &mut record.buf)?;
-    record.bounds.alternate_bases_end = record.buf.len();
-
-    len += read_field(reader, &mut record.buf)?;
-    record.bounds.quality_score_end = record.buf.len();
-
-    len += read_field(reader, &mut record.buf)?;
-    record.bounds.filters_end = record.buf.len();
-
-    len += read_field(reader, &mut record.buf)?;
-    record.bounds.info_end = record.buf.len();
-
-    len += read_line(reader, &mut record.buf)?;
-
-    Ok(len)
-}
-
-fn read_field<R>(reader: &mut R, dst: &mut String) -> io::Result<usize>
-where
-    R: BufRead,
-{
-    const DELIMITER: u8 = b'\t';
-
-    let mut is_delimiter = false;
-    let mut len = 0;
-
-    loop {
-        let src = reader.fill_buf()?;
-
-        if is_delimiter || src.is_empty() {
-            break;
-        }
-
-        let (buf, n) = match src.iter().position(|&b| b == DELIMITER) {
-            Some(i) => {
-                is_delimiter = true;
-                (&src[..i], i + 1)
-            }
-            None => (src, src.len()),
-        };
-
-        let s = str::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        dst.push_str(s);
-
-        len += n;
-
-        reader.consume(n);
-    }
-
-    Ok(len)
-}
-
 pub(crate) fn resolve_region<I>(index: &I, region: &Region) -> io::Result<(usize, Vec<u8>)>
 where
     I: BinningIndex,
@@ -538,27 +467,6 @@ sq0\t1\t.\tA\t.\t.\tPASS\t.
         buf.clear();
         read_line(&mut reader, &mut buf)?;
         assert_eq!(buf, "noodles");
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_read_lazy_record() -> io::Result<()> {
-        let mut src = &b"sq0\t1\t.\tA\t.\t.\tPASS\t."[..];
-
-        let mut record = lazy::Record::default();
-        read_lazy_record(&mut src, &mut record)?;
-
-        assert_eq!(record.buf, "sq01.A..PASS.");
-
-        assert_eq!(record.bounds.chromosome_end, 3);
-        assert_eq!(record.bounds.position_end, 4);
-        assert_eq!(record.bounds.ids_end, 5);
-        assert_eq!(record.bounds.reference_bases_end, 6);
-        assert_eq!(record.bounds.alternate_bases_end, 7);
-        assert_eq!(record.bounds.quality_score_end, 8);
-        assert_eq!(record.bounds.filters_end, 12);
-        assert_eq!(record.bounds.info_end, 13);
 
         Ok(())
     }

--- a/noodles-vcf/src/reader.rs
+++ b/noodles-vcf/src/reader.rs
@@ -2,7 +2,7 @@
 
 mod builder;
 mod header;
-mod lazy_record;
+pub(crate) mod lazy_record;
 pub(crate) mod query;
 pub mod record;
 mod records;

--- a/noodles-vcf/src/reader/lazy_record.rs
+++ b/noodles-vcf/src/reader/lazy_record.rs
@@ -1,0 +1,105 @@
+use std::{
+    io::{self, BufRead},
+    str,
+};
+
+use super::read_line;
+use crate::lazy;
+
+pub(super) fn read_lazy_record<R>(reader: &mut R, record: &mut lazy::Record) -> io::Result<usize>
+where
+    R: BufRead,
+{
+    record.buf.clear();
+
+    let mut len = 0;
+
+    len += read_field(reader, &mut record.buf)?;
+    record.bounds.chromosome_end = record.buf.len();
+
+    len += read_field(reader, &mut record.buf)?;
+    record.bounds.position_end = record.buf.len();
+
+    len += read_field(reader, &mut record.buf)?;
+    record.bounds.ids_end = record.buf.len();
+
+    len += read_field(reader, &mut record.buf)?;
+    record.bounds.reference_bases_end = record.buf.len();
+
+    len += read_field(reader, &mut record.buf)?;
+    record.bounds.alternate_bases_end = record.buf.len();
+
+    len += read_field(reader, &mut record.buf)?;
+    record.bounds.quality_score_end = record.buf.len();
+
+    len += read_field(reader, &mut record.buf)?;
+    record.bounds.filters_end = record.buf.len();
+
+    len += read_field(reader, &mut record.buf)?;
+    record.bounds.info_end = record.buf.len();
+
+    len += read_line(reader, &mut record.buf)?;
+
+    Ok(len)
+}
+
+fn read_field<R>(reader: &mut R, dst: &mut String) -> io::Result<usize>
+where
+    R: BufRead,
+{
+    const DELIMITER: u8 = b'\t';
+
+    let mut is_delimiter = false;
+    let mut len = 0;
+
+    loop {
+        let src = reader.fill_buf()?;
+
+        if is_delimiter || src.is_empty() {
+            break;
+        }
+
+        let (buf, n) = match src.iter().position(|&b| b == DELIMITER) {
+            Some(i) => {
+                is_delimiter = true;
+                (&src[..i], i + 1)
+            }
+            None => (src, src.len()),
+        };
+
+        let s = str::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        dst.push_str(s);
+
+        len += n;
+
+        reader.consume(n);
+    }
+
+    Ok(len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_lazy_record() -> io::Result<()> {
+        let mut src = &b"sq0\t1\t.\tA\t.\t.\tPASS\t."[..];
+
+        let mut record = lazy::Record::default();
+        read_lazy_record(&mut src, &mut record)?;
+
+        assert_eq!(record.buf, "sq01.A..PASS.");
+
+        assert_eq!(record.bounds.chromosome_end, 3);
+        assert_eq!(record.bounds.position_end, 4);
+        assert_eq!(record.bounds.ids_end, 5);
+        assert_eq!(record.bounds.reference_bases_end, 6);
+        assert_eq!(record.bounds.alternate_bases_end, 7);
+        assert_eq!(record.bounds.quality_score_end, 8);
+        assert_eq!(record.bounds.filters_end, 12);
+        assert_eq!(record.bounds.info_end, 13);
+
+        Ok(())
+    }
+}

--- a/noodles-vcf/src/reader/lazy_record.rs
+++ b/noodles-vcf/src/reader/lazy_record.rs
@@ -6,7 +6,7 @@ use std::{
 use super::read_line;
 use crate::lazy;
 
-pub(super) fn read_lazy_record<R>(reader: &mut R, record: &mut lazy::Record) -> io::Result<usize>
+pub(crate) fn read_lazy_record<R>(reader: &mut R, record: &mut lazy::Record) -> io::Result<usize>
 where
     R: BufRead,
 {


### PR DESCRIPTION
Hi, using the lazy vcf reader, I think I found an issue w.r.t. how the fields are being parsed. In cases where not all fields are present, `read_field` will read into the next line causing `record.buf` to contain the record in question as it was parsed and the "raw" next record (because of the last `read_line` in `read_lazy_record`).

For example, if you modify test_read_lazy_record test to have two records, `&b"sq0\t1\t.\tA\t.\t.\tPASS\t.\nsq0\t1\t.\tA\t.\t.\tPASS\t."[..];`, the test fails because `record.buf` is actually `sq01.A..PASS.\nsq01\t.\tA\t.\t.\tPASS\t.` (the samples field has the next record).

```rust
    #[tokio::test]
    async fn test_read_lazy_record() -> io::Result<()> {
        let mut src = &b"sq0\t1\t.\tA\t.\t.\tPASS\t.\nsq0\t1\t.\tA\t.\t.\tPASS\t."[..];

        let mut record = lazy::Record::default();
        read_lazy_record(&mut src, &mut record).await?;

        assert_eq!(record.buf, "sq01.A..PASS.");

        assert_eq!(record.bounds.chromosome_end, 3);
        assert_eq!(record.bounds.position_end, 4);
        assert_eq!(record.bounds.ids_end, 5);
        assert_eq!(record.bounds.reference_bases_end, 6);
        assert_eq!(record.bounds.alternate_bases_end, 7);
        assert_eq!(record.bounds.quality_score_end, 8);
        assert_eq!(record.bounds.filters_end, 12);
        assert_eq!(record.bounds.info_end, 13);

        Ok(())
    }
```

To attempt a fix, I took perhaps the dumbest and least idiomatic approach :), but I thought I'd open it up to see if you agree there's an issue and if so, thoughts on the best way to fix it.

Thanks,