### PR TITLE
Add new BAM example for full PG entry

### DIFF
--- a/noodles-bam/examples/bam_add_tag_to_header.rs
+++ b/noodles-bam/examples/bam_add_tag_to_header.rs
@@ -8,7 +8,7 @@ use std::{env, io};
 
 use noodles_bam as bam;
 use noodles_sam::header::record::value::{
-    map::{Program, Tag},
+    map::{program::tag, Program},
     Map,
 };
 use noodles_sam::Header;
@@ -17,37 +17,20 @@ fn add_pg(mut header: Header) -> Header {
     const NAME: &str = "bam_add_tag_to_header";
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-    // standard PG tags PN, VN, PP, CL
-    let pn = match Tag::try_from([b'P', b'N']) {
-        Ok(Tag::Other(tag)) => tag,
-        _ => unreachable!(),
-    };
-    let vn = match Tag::try_from([b'V', b'N']) {
-        Ok(Tag::Other(tag)) => tag,
-        _ => unreachable!(),
-    };
-    let pp = match Tag::try_from([b'P', b'P']) {
-        Ok(Tag::Other(tag)) => tag,
-        _ => unreachable!(),
-    };
-    let cl = match Tag::try_from([b'C', b'L']) {
-        Ok(Tag::Other(tag)) => tag,
-        _ => unreachable!(),
-    };
     // the command-line to insert into the CL tag
     let cmd_str = env::args().collect::<Vec<_>>().join(" ");
 
-    let program = Map::<Program>::builder().insert(pn, NAME);
+    let program = Map::<Program>::builder().insert(tag::NAME, NAME);
 
     let program = if let Some(last_pg) = header.programs().keys().last() {
-        program.insert(pp, last_pg.clone())
+        program.insert(tag::PREVIOUS_PROGRAM_ID, last_pg.clone())
     } else {
         program
     };
 
     let program = program
-        .insert(vn, VERSION)
-        .insert(cl, cmd_str)
+        .insert(tag::VERSION, VERSION)
+        .insert(tag::COMMAND_LINE, cmd_str)
         .build()
         .unwrap();
     header.programs_mut().insert(NAME.into(), program);

--- a/noodles-bam/examples/bam_add_tag_to_header.rs
+++ b/noodles-bam/examples/bam_add_tag_to_header.rs
@@ -1,0 +1,73 @@
+//! Add a PG tag to the SAM header of a BAM file.
+//!
+//! This is a demonstration of how to construct a full PG entry.
+//!
+//! Verify the output by piping to `samtools view --with-header`.
+
+use std::{env, io};
+
+use noodles_bam as bam;
+use noodles_sam::header::record::value::{
+    map::{Program, Tag},
+    Map,
+};
+use noodles_sam::Header;
+
+const NAME: &str = "bam_add_tag";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn add_pg(mut header: Header) -> Header {
+    // standard PG tags PN, VN, PP, CL
+    let pn = match Tag::try_from([b'P', b'N']) {
+        Ok(Tag::Other(tag)) => tag,
+        _ => unreachable!(),
+    };
+    let vn = match Tag::try_from([b'V', b'N']) {
+        Ok(Tag::Other(tag)) => tag,
+        _ => unreachable!(),
+    };
+    let pp = match Tag::try_from([b'P', b'P']) {
+        Ok(Tag::Other(tag)) => tag,
+        _ => unreachable!(),
+    };
+    let cl = match Tag::try_from([b'C', b'L']) {
+        Ok(Tag::Other(tag)) => tag,
+        _ => unreachable!(),
+    };
+    // the command-line to insert into the CL tag
+    let cmd_str = env::args().collect::<Vec<_>>().join(" ");
+
+    let program = Map::<Program>::builder().insert(pn, NAME);
+
+    let program = if let Some(last_pg) = header.programs().iter().last() {
+        program.insert(pp, last_pg.0.clone())
+    } else {
+        program
+    };
+
+    let program = program
+        .insert(vn, VERSION)
+        .insert(cl, cmd_str)
+        .build()
+        .unwrap();
+    header.programs_mut().insert(NAME.into(), program);
+
+    header
+}
+
+fn main() -> io::Result<()> {
+    let src = env::args().nth(1).expect("missing src");
+
+    let mut reader = bam::io::reader::Builder.build_from_path(src)?;
+
+    let header = add_pg(reader.read_header()?);
+
+    let stdout = io::stdout().lock();
+    let mut writer = bam::io::Writer::new(stdout);
+
+    writer.write_header(&header)?;
+
+    io::copy(reader.get_mut(), writer.get_mut())?;
+
+    Ok(())
+}

--- a/noodles-bam/examples/bam_add_tag_to_header.rs
+++ b/noodles-bam/examples/bam_add_tag_to_header.rs
@@ -13,10 +13,10 @@ use noodles_sam::header::record::value::{
 };
 use noodles_sam::Header;
 
-const NAME: &str = "bam_add_tag";
-const VERSION: &str = env!("CARGO_PKG_VERSION");
-
 fn add_pg(mut header: Header) -> Header {
+    const NAME: &str = "bam_add_tag";
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+
     // standard PG tags PN, VN, PP, CL
     let pn = match Tag::try_from([b'P', b'N']) {
         Ok(Tag::Other(tag)) => tag,
@@ -39,8 +39,8 @@ fn add_pg(mut header: Header) -> Header {
 
     let program = Map::<Program>::builder().insert(pn, NAME);
 
-    let program = if let Some(last_pg) = header.programs().iter().last() {
-        program.insert(pp, last_pg.0.clone())
+    let program = if let Some(last_pg) = header.programs().keys().last() {
+        program.insert(pp, last_pg.clone())
     } else {
         program
     };

--- a/noodles-bam/examples/bam_add_tag_to_header.rs
+++ b/noodles-bam/examples/bam_add_tag_to_header.rs
@@ -14,7 +14,7 @@ use noodles_sam::header::record::value::{
 use noodles_sam::Header;
 
 fn add_pg(mut header: Header) -> Header {
-    const NAME: &str = "bam_add_tag";
+    const NAME: &str = "bam_add_tag_to_header";
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
     // standard PG tags PN, VN, PP, CL


### PR DESCRIPTION
This is an example script that adds a full PG tag to the header of a BAM file (`sample.bam` is the output of `bam_write`):

```
@HD	VN:1.6
@PG	ID:noodles-bam
@PG	ID:bam_add_tag	PN:bam_add_tag	PP:noodles-bam	VN:0.57.0	CL:target/release/examples/bam_add_tag_to_header sample.bam
@PG	ID:samtools	PN:samtools	PP:bam_add_tag	VN:1.19	CL:samtools view --with-header
@CO	an example BAM written by noodles-bam
*	4	*	0	255	*	*	0	0	*	*
```

I spent some time yesterday figuring out how to do this, and I figured the example might be useful. I'm also opening the PR to see if there are any improvements you can see.

The name could be more clear, perhaps `bam_add_pg_entry` would be better. People might expect "tag" to refer to the reads.

Constructing the `PN`, `PP`, `VN`, and `CL` tags seems cumbersome. Maybe these should be built-in tags (I believe they're part of the spec). Or if there's a way to construct them more cleanly I'd be happy to use that.