### PR TITLE
Add async alignment writer

### DIFF
--- a/noodles-util/src/alignment/async/io.rs
+++ b/noodles-util/src/alignment/async/io.rs
@@ -1,5 +1,7 @@
 //! Async alignment format I/O.
 
 pub mod reader;
+pub mod writer;
 
 pub use self::reader::Reader;
+pub use self::writer::Writer;

--- a/noodles-util/src/alignment/async/io/writer.rs
+++ b/noodles-util/src/alignment/async/io/writer.rs
@@ -1,0 +1,83 @@
+//! Async alignment writer.
+
+mod builder;
+
+use noodles_bam as bam;
+use noodles_cram as cram;
+use noodles_sam as sam;
+use tokio::io::{self, AsyncWrite};
+
+pub use self::builder::Builder;
+
+/// An async alignment writer.
+pub enum Writer<W: tokio::io::AsyncWrite> {
+    /// SAM.
+    Sam(sam::r#async::io::Writer<W>),
+    /// BAM.
+    Bam(bam::r#async::io::Writer<W>),
+    /// CRAM.
+    Cram(cram::r#async::io::Writer<W>),
+}
+
+impl<W> Writer<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    /// Writes a SAM header.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> tokio::io::Result<()> {
+    /// use noodles_sam as sam;
+    /// use noodles_util::alignment::r#async::io::writer::Builder;
+    /// use tokio::io;
+    /// use tokio::io::AsyncWriteExt;
+    ///
+    /// let mut writer = Builder::default().build_from_writer(io::sink());
+    ///
+    /// let header = sam::Header::default();
+    /// writer.write_header(&header).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn write_header(&mut self, header: &sam::Header) -> io::Result<()> {
+        match self {
+            Self::Sam(writer) => writer.write_header(header).await,
+            Self::Bam(writer) => writer.write_header(header).await,
+            Self::Cram(writer) => writer.write_file_header(header).await,
+        }
+    }
+
+    /// Writes an alignment record.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> tokio::io::Result<()> {
+    /// use noodles_sam as sam;
+    /// use noodles_util::alignment::r#async::io::writer::Builder;
+    /// use tokio::io;
+    /// use tokio::io::AsyncWriteExt;
+    ///
+    /// let mut writer = Builder::default().build_from_writer(io::sink());
+    ///
+    /// let record = sam::Record::default();
+    /// writer.write_record(&record).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn write_record(
+        &mut self,
+        header: &sam::Header,
+        record: &dyn sam::alignment::Record,
+    ) -> io::Result<()> {
+        match self {
+            Self::Sam(writer) => writer.write_alignment_record(header, record).await,
+            Self::Bam(writer) => writer.write_alignment_record(header, record).await,
+            Self::Cram(writer) => writer.write_record(header, record).await,
+        }
+    }
+}

--- a/noodles-util/src/alignment/async/io/writer/builder.rs
+++ b/noodles-util/src/alignment/async/io/writer/builder.rs
@@ -1,0 +1,183 @@
+use std::path::Path;
+
+use noodles_bam as bam;
+use noodles_bgzf as bgzf;
+use noodles_cram as cram;
+use noodles_fasta as fasta;
+use noodles_sam as sam;
+use tokio::{
+    fs::File,
+    io::{self, AsyncWrite},
+};
+
+use super::Writer;
+use crate::alignment::io::{CompressionMethod, Format};
+
+/// An async alignment writer builder.
+#[derive(Default)]
+pub struct Builder {
+    compression_method: Option<Option<CompressionMethod>>,
+    format: Option<Format>,
+    reference_sequence_repository: fasta::Repository,
+}
+
+impl Builder {
+    /// Sets the compression method.
+    ///
+    /// By default, the compression method is autodetected on build. This can be used to override
+    /// it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_util::alignment::{r#async::io::writer::Builder, io::CompressionMethod};
+    /// let builder = Builder::default().set_compression_method(Some(CompressionMethod::Bgzf));
+    /// ```
+    pub fn set_compression_method(mut self, compression_method: Option<CompressionMethod>) -> Self {
+        self.compression_method = Some(compression_method);
+        self
+    }
+
+    /// Sets the format of the output.
+    ///
+    /// By default, the format is autodetected on build. This can be used to override it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_util::alignment::{r#async::io::writer::Builder, io::Format};
+    /// let builder = Builder::default().set_format(Format::Sam);
+    /// ```
+    pub fn set_format(mut self, format: Format) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Sets the reference sequence repository.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_fasta as fasta;
+    /// use noodles_util::alignment::{r#async::io::writer::Builder, io::Format};
+    /// let repository = fasta::Repository::default();
+    /// let builder = Builder::default().set_reference_sequence_repository(repository);
+    /// ```
+    pub fn set_reference_sequence_repository(
+        mut self,
+        reference_sequence_repository: fasta::Repository,
+    ) -> Self {
+        self.reference_sequence_repository = reference_sequence_repository;
+        self
+    }
+
+    /// Builds an async alignment writer from a path.
+    ///
+    /// By default, the format and compression method will be detected from the path extension.
+    /// This can be overridden by using [`Self::set_format`] and [`Self::set_compression_method`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> tokio::io::Result<()> {
+    /// use noodles_util::alignment::r#async::io::reader::Builder;
+    /// let reader = Builder::default().build_from_path("sample.bam").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn build_from_path<P>(
+        mut self,
+        src: P,
+    ) -> io::Result<Writer<Box<dyn AsyncWrite + Unpin>>>
+    where
+        P: AsRef<Path>,
+    {
+        use crate::alignment::io::writer::builder::{
+            detect_compression_method_from_path_extension, detect_format_from_path_extension,
+        };
+
+        let src = src.as_ref();
+
+        if self.compression_method.is_none() {
+            self.compression_method = Some(detect_compression_method_from_path_extension(src));
+        }
+
+        if self.format.is_none() {
+            self.format = detect_format_from_path_extension(src);
+        }
+
+        File::create(src)
+            .await
+            .map(|file| self.build_from_writer(file))?
+    }
+
+    /// Builds an async alignment writer from a writer.
+    ///
+    /// If the format is not set, a default format is used. If the compression method is not set, a
+    /// default one is determined by the format.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> tokio::io::Result<()> {
+    /// use noodles_util::alignment::r#async::io::writer::Builder;
+    /// use tokio::io;
+    /// let reader = Builder::default().build_from_writer(io::sink()).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn build_from_writer<W>(self, writer: W) -> io::Result<Writer<Box<dyn AsyncWrite + Unpin>>>
+    where
+        W: AsyncWrite + Unpin + 'static,
+    {
+        use bam::r#async::io::Writer as AsyncBamWriter;
+        use sam::r#async::io::Writer as AsyncSamWriter;
+
+        let format = self.format.unwrap_or(Format::Sam);
+
+        let compression_method = match self.compression_method {
+            Some(compression_method) => compression_method,
+            None => match format {
+                Format::Sam | Format::Cram => None,
+                Format::Bam => Some(CompressionMethod::Bgzf),
+            },
+        };
+
+        let writer = match (format, compression_method) {
+            (Format::Sam, None) => {
+                let inner: Box<dyn AsyncWrite + Unpin> = Box::new(writer);
+                Writer::Sam(AsyncSamWriter::new(inner))
+            }
+            (Format::Sam, Some(CompressionMethod::Bgzf)) => {
+                let encoder: Box<dyn AsyncWrite + Unpin> = Box::new(bgzf::AsyncWriter::new(writer));
+                Writer::Sam(AsyncSamWriter::new(encoder))
+            }
+            (Format::Bam, None) => {
+                let inner: Box<dyn AsyncWrite + Unpin> = Box::new(writer);
+                Writer::Bam(AsyncBamWriter::from(inner))
+            }
+            (Format::Bam, Some(CompressionMethod::Bgzf)) => {
+                let encoder: Box<dyn AsyncWrite + Unpin> = Box::new(bgzf::AsyncWriter::new(writer));
+                Writer::Bam(AsyncBamWriter::from(encoder))
+            }
+            (Format::Cram, None) => {
+                let inner: Box<dyn AsyncWrite + Unpin> = Box::new(writer);
+                let inner = cram::r#async::io::writer::Builder::default()
+                    .set_reference_sequence_repository(self.reference_sequence_repository)
+                    .build_with_writer(inner);
+                Writer::Cram(inner)
+            }
+            (Format::Cram, Some(CompressionMethod::Bgzf)) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "CRAM cannot be compressed with BGZF",
+                ));
+            }
+
+        };
+
+        Ok(writer)
+    }
+}

--- a/noodles-util/src/alignment/io/writer/builder.rs
+++ b/noodles-util/src/alignment/io/writer/builder.rs
@@ -186,7 +186,7 @@ impl Builder {
     }
 }
 
-fn detect_compression_method_from_path_extension<P>(path: P) -> Option<CompressionMethod>
+pub(crate) fn detect_compression_method_from_path_extension<P>(path: P) -> Option<CompressionMethod>
 where
     P: AsRef<Path>,
 {
@@ -196,7 +196,7 @@ where
     }
 }
 
-fn detect_format_from_path_extension<P>(path: P) -> Option<Format>
+pub(crate) fn detect_format_from_path_extension<P>(path: P) -> Option<Format>
 where
     P: AsRef<Path>,
 {


### PR DESCRIPTION
See #286 for more details. 

Checklist

- [ ] async Writer
- [x] Builder
- [x] Documentation examples
- [ ] `examples/` entry

Currently, I cannot compile the async Writer due to

```
error[E0308]: mismatched types
   --> noodles-util/src/alignment/async/io/writer.rs:80:63
    |
80  |             Self::Cram(writer) => writer.write_record(header, record).await,
    |                                          ------------         ^^^^^^ expected `Record`, found `&dyn Record`
    |                                          |
    |                                          arguments to this method are incorrect
    |
    = note: expected struct `noodles_cram::Record`
            found reference `&dyn noodles_sam::alignment::Record`
note: method defined here
   --> /Users/michael/Projects/noodles/noodles-cram/src/async/io/writer.rs:181:18
    |
181 |     pub async fn write_record(
    |                  ^^^^^^^^^^^^
```

Which is coming from the fact that `cram::async::io::Writer::write_record` takes a `cram::Record` type rather than a `&dyn sam::alignment::Record` trait.

https://github.com/zaeleus/noodles/blob/174ad3c98092728a6be3feabb346619ebd14a5ad/noodles-cram/src/async/io/writer.rs#L184

Is that a change that should be made in a separate PR?

In addition, I also noticed some slight differences in function naming schemes between SAM/BAM and CRAM. For example, the SAM and BAM async `Writer`s have a `write_header` function, however, the reciprocal CRAM function is `write_file_header` - not sure if this was intended though. Also, the CRAM async builder has the function `build_with_writer` rather than the `build_from_writer`. I appreciate these are minor things, but thought I would raise them in case you want to move this library towards consistent names across modules/crates. I guess for backwards compatibility we could add the [`#[deprecated`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute) attribute if you want to introduce the consistent named version.