### PR TITLE
Refget: Handle non-successful status codes

### DIFF
--- a/noodles-refget/CHANGELOG.md
+++ b/noodles-refget/CHANGELOG.md
@@ -6,6 +6,12 @@
 
   * refget: Raise minimum supported Rust version (MSRV) to 1.81.0.
 
+  * refget/sequence: Handle response failures ([#322]).
+
+    Response errors now wrap the HTTP client error as `Error::Response`.
+
+[#322]: https://github.com/zaeleus/noodles/issues/332
+
 ## 0.6.0 - 2025-01-19
 
 ### Changed

--- a/noodles-refget/src/lib.rs
+++ b/noodles-refget/src/lib.rs
@@ -20,6 +20,8 @@ pub enum Error {
     Url(url::ParseError),
     /// The request failed to process.
     Request(reqwest::Error),
+    /// The response had an unsuccessful HTTP status code.  
+    Response(reqwest::Error),
 }
 
 impl error::Error for Error {
@@ -28,6 +30,17 @@ impl error::Error for Error {
             Self::Input => None,
             Self::Url(e) => Some(e),
             Self::Request(e) => Some(e),
+            Self::Response(e) => Some(e),
+        }
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        if err.is_status() {
+            Error::Response(err)
+        } else {
+            Error::Request(err)
         }
     }
 }
@@ -38,6 +51,7 @@ impl fmt::Display for Error {
             Self::Input => f.write_str("invalid input"),
             Self::Url(_) => f.write_str("URL error"),
             Self::Request(_) => f.write_str("request error"),
+            Self::Response(_) => f.write_str("response error"),
         }
     }
 }

--- a/noodles-refget/src/sequence/builder.rs
+++ b/noodles-refget/src/sequence/builder.rs
@@ -56,8 +56,8 @@ impl Builder {
             request = request.query(&query);
         }
 
-        let response = request.send().await.map_err(Error::Request)?;
-        let sequence = response.bytes().await.map_err(Error::Request)?;
+        let response = request.send().await?.error_for_status()?;
+        let sequence = response.bytes().await?;
 
         Ok(Sequence::new(self.client, self.id, sequence))
     }

--- a/noodles-refget/src/sequence/metadata/builder.rs
+++ b/noodles-refget/src/sequence/metadata/builder.rs
@@ -33,14 +33,15 @@ impl Builder {
             .http_client()
             .get(endpoint)
             .send()
-            .await
-            .map_err(Error::Request)?;
+            .await?
+            .error_for_status()?;
 
-        response
+        let metadata = response
             .json()
             .await
-            .map(|data: MetadataResponse| data.metadata)
-            .map_err(Error::Request)
+            .map(|data: MetadataResponse| data.metadata)?;
+
+        Ok(metadata)
     }
 }
 

--- a/noodles-refget/src/sequence/service/builder.rs
+++ b/noodles-refget/src/sequence/service/builder.rs
@@ -26,14 +26,15 @@ impl Builder {
             .http_client()
             .get(endpoint)
             .send()
-            .await
-            .map_err(Error::Request)?;
+            .await?
+            .error_for_status()?;
 
-        response
+        let service = response
             .json()
             .await
-            .map(|data: ServiceInfoResponse| data.refget)
-            .map_err(Error::Request)
+            .map(|data: ServiceInfoResponse| data.refget)?;
+
+        Ok(service)
     }
 }
 


### PR DESCRIPTION
A proposed solution to handle non-successful status codes in the refget client (fixes #332).

- Throws an informative error with the non-successful response status code (these cases weren't directly handled before).
- Introduces the `Response` error, similar to the current htsget implementation.
- Slightly simplifies the error handling in the response.