### PR TITLE
vcf/record/info: Avoid parsing skipped fields

### DIFF
--- a/noodles-vcf/src/record/info/field.rs
+++ b/noodles-vcf/src/record/info/field.rs
@@ -6,28 +6,20 @@ use self::value::parse_value;
 use crate::{header::record::value::map::info::Type, variant::record::info::field::Value, Header};
 
 pub(super) fn parse_field<'a>(
-    src: &mut &'a str,
+    buf: &'a str,
     header: &Header,
 ) -> io::Result<(&'a str, Option<Value<'a>>)> {
     use crate::header::record::value::map::info::definition::definition;
 
-    const DELIMITER: char = ';';
     const MAX_COMPONENTS: usize = 2;
     const MISSING: &str = ".";
     const SEPARATOR: char = '=';
 
-    let (buf, rest) = match src.find(DELIMITER) {
-        Some(i) => {
-            let (buf, rest) = src.split_at(i);
-            (buf, &rest[1..])
-        }
-        None => src.split_at(src.len()),
-    };
-
-    *src = rest;
-
     if buf.is_empty() {
-        return Err(io::Error::from(io::ErrorKind::UnexpectedEof));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "empty info field",
+        ));
     }
 
     let mut components = buf.splitn(MAX_COMPONENTS, SEPARATOR);
@@ -50,7 +42,12 @@ pub(super) fn parse_field<'a>(
         Some(MISSING) => None,
         Some(t) => parse_value(t, number, ty).map(Some)?,
         None if ty == Type::Flag => Some(Value::Flag),
-        None => return Err(io::Error::new(io::ErrorKind::InvalidData, "missing value")),
+        None => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "missing info field value",
+            ))
+        }
     };
 
     Ok((key, value))


### PR DESCRIPTION
I have an indexed vcf file, and my program was spending ~half the time (according to a quick flamegraph) parsing the info fields looking for `END` while querying it.
This just skips the parsing of the fields we don't care about on `get`. `variant_end` goes from ~45% to ~14%[1] the flamegraph for my usecase, not the most accurate assessment, but the change seems straightforward enough.

Thank you for the great libraries!

[1] It's very noisy, but it settled around here after some more extreme initial numbers.