### PR TITLE
feat: `len()` and `iter()` implementations for quality scores

### DIFF
--- a/noodles-bam/src/record/quality_scores.rs
+++ b/noodles-bam/src/record/quality_scores.rs
@@ -21,7 +21,7 @@ impl<'a> QualityScores<'a> {
         self.0.len()
     }
 
-    /// Returns an iterator over the scores
+    /// Returns an iterator over the scores.
     pub fn iter(&self) -> impl Iterator<Item = u8> + 'a {
         self.0.iter().copied()
     }

--- a/noodles-sam/src/alignment/record_buf/quality_scores.rs
+++ b/noodles-sam/src/alignment/record_buf/quality_scores.rs
@@ -20,7 +20,7 @@ impl QualityScores {
         self.0.len()
     }
 
-    /// Returns an iterator over the scores
+    /// Returns an iterator over the scores.
     pub fn iter(&self) -> impl Iterator<Item = u8> + '_ {
         self.0.iter().copied()
     }


### PR DESCRIPTION
A small QOL update to quality score structs that _do not_ implement `noodles_sam::src::alignment::quality_scores::QualityScores`. This PR adds `len()` and `iter()` implementations that one would expect for a list-like structs of quality scores.