### PR TITLE
util: Add Send to async io builders return type

### DIFF
--- a/noodles-util/src/variant/async/io/reader.rs
+++ b/noodles-util/src/variant/async/io/reader.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use futures::{Stream, StreamExt};
 use noodles_bcf as bcf;
 use noodles_vcf as vcf;
-use tokio::io::{self, AsyncBufRead};
+use tokio::io::{self, AsyncBufRead, AsyncRead};
 
 pub use self::builder::Builder;
 
@@ -92,7 +92,7 @@ where
     }
 }
 
-impl<'a> Reader<Box<dyn AsyncBufRead + Unpin + 'a>> {
+impl<'a> Reader<Box<dyn AsyncBufRead + Send + Unpin + 'a>> {
     /// Creates a variant reader.
     ///
     /// This attempts to autodetect the compression method and format of the input.
@@ -108,7 +108,7 @@ impl<'a> Reader<Box<dyn AsyncBufRead + Unpin + 'a>> {
     /// ```
     pub async fn new<R>(reader: R) -> io::Result<Self>
     where
-        R: AsyncBufRead + Unpin + 'a,
+        R: AsyncRead + Send + Unpin + 'a,
     {
         Builder::default().build_from_reader(reader).await
     }

--- a/noodles-util/src/variant/async/io/reader/builder.rs
+++ b/noodles-util/src/variant/async/io/reader/builder.rs
@@ -68,7 +68,7 @@ impl Builder {
     pub async fn build_from_path<P>(
         self,
         src: P,
-    ) -> io::Result<Reader<Box<dyn AsyncBufRead + Unpin>>>
+    ) -> io::Result<Reader<Box<dyn AsyncBufRead + Send + Unpin>>>
     where
         P: AsRef<Path>,
     {
@@ -95,9 +95,9 @@ impl Builder {
     pub async fn build_from_reader<'a, R>(
         self,
         reader: R,
-    ) -> io::Result<Reader<Box<dyn AsyncBufRead + Unpin + 'a>>>
+    ) -> io::Result<Reader<Box<dyn AsyncBufRead + Send + Unpin + 'a>>>
     where
-        R: AsyncRead + Unpin + 'a,
+        R: AsyncRead + Send + Unpin + 'a,
     {
         use crate::variant::io::reader::builder::{detect_compression_method, detect_format};
 
@@ -121,20 +121,20 @@ impl Builder {
 
         let reader = match (format, compression_method) {
             (Format::Vcf, None) => {
-                let inner: Box<dyn AsyncBufRead + Unpin> = Box::new(reader);
+                let inner: Box<dyn AsyncBufRead + Send + Unpin> = Box::new(reader);
                 Reader::Vcf(vcf::r#async::io::Reader::new(inner))
             }
             (Format::Vcf, Some(CompressionMethod::Bgzf)) => {
-                let decoder: Box<dyn AsyncBufRead + Unpin> =
+                let decoder: Box<dyn AsyncBufRead + Send + Unpin> =
                     Box::new(bgzf::r#async::io::Reader::new(reader));
                 Reader::Vcf(vcf::r#async::io::Reader::new(decoder))
             }
             (Format::Bcf, None) => {
-                let inner: Box<dyn AsyncBufRead + Unpin> = Box::new(reader);
+                let inner: Box<dyn AsyncBufRead + Send + Unpin> = Box::new(reader);
                 Reader::Bcf(bcf::r#async::io::Reader::from(inner))
             }
             (Format::Bcf, Some(CompressionMethod::Bgzf)) => {
-                let decoder: Box<dyn AsyncBufRead + Unpin> =
+                let decoder: Box<dyn AsyncBufRead + Send + Unpin> =
                     Box::new(bgzf::r#async::io::Reader::new(reader));
                 Reader::Bcf(bcf::r#async::io::Reader::from(decoder))
             }

--- a/noodles-util/src/variant/async/io/writer/builder.rs
+++ b/noodles-util/src/variant/async/io/writer/builder.rs
@@ -62,7 +62,7 @@ impl Builder {
     pub async fn build_from_path<P>(
         mut self,
         src: P,
-    ) -> io::Result<Writer<Box<dyn AsyncWrite + Unpin>>>
+    ) -> io::Result<Writer<Box<dyn AsyncWrite + Send + Unpin>>>
     where
         P: AsRef<Path>,
     {
@@ -101,9 +101,9 @@ impl Builder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn build_from_writer<W>(self, writer: W) -> Writer<Box<dyn AsyncWrite + Unpin>>
+    pub fn build_from_writer<W>(self, writer: W) -> Writer<Box<dyn AsyncWrite + Send + Unpin>>
     where
-        W: AsyncWrite + Unpin + 'static,
+        W: AsyncWrite + Send + Unpin + 'static,
     {
         let format = self.format.unwrap_or(Format::Vcf);
 
@@ -117,20 +117,20 @@ impl Builder {
 
         match (format, compression_method) {
             (Format::Vcf, None) => {
-                let inner: Box<dyn AsyncWrite + Unpin> = Box::new(writer);
+                let inner: Box<dyn AsyncWrite + Send + Unpin> = Box::new(writer);
                 Writer::Vcf(vcf::r#async::io::Writer::new(inner))
             }
             (Format::Vcf, Some(CompressionMethod::Bgzf)) => {
-                let encoder: Box<dyn AsyncWrite + Unpin> =
+                let encoder: Box<dyn AsyncWrite + Send + Unpin> =
                     Box::new(bgzf::r#async::io::Writer::new(writer));
                 Writer::Vcf(vcf::r#async::io::Writer::new(encoder))
             }
             (Format::Bcf, None) => {
-                let inner: Box<dyn AsyncWrite + Unpin> = Box::new(writer);
+                let inner: Box<dyn AsyncWrite + Send + Unpin> = Box::new(writer);
                 Writer::Bcf(bcf::r#async::io::Writer::from(inner))
             }
             (Format::Bcf, Some(CompressionMethod::Bgzf)) => {
-                let encoder: Box<dyn AsyncWrite + Unpin> =
+                let encoder: Box<dyn AsyncWrite + Send + Unpin> =
                     Box::new(bgzf::r#async::io::Writer::new(writer));
                 Writer::Bcf(bcf::r#async::io::Writer::from(encoder))
             }


### PR DESCRIPTION
Breaking change since the builder functions now require Send on the underlying reader.

Applies to the variant and alignment readers and writers.

I argue that since we operate in async land here, the returning types should be guaranteed to implement Send, to be used across await calls.