### PR TITLE
move from unmaintained xz2 to liblzma

### DIFF
--- a/noodles-cram/Cargo.toml
+++ b/noodles-cram/Cargo.toml
@@ -26,7 +26,7 @@ noodles-bam = { path = "../noodles-bam", version = "0.83.0" }
 noodles-core = { path = "../noodles-core", version = "0.18.0" }
 noodles-fasta = { path = "../noodles-fasta", version = "0.56.0" }
 noodles-sam = { path = "../noodles-sam", version = "0.79.0" }
-xz2 = "0.1.6"
+liblzma = "0.3.6"
 
 async-compression = { version = "0.4.0", optional = true, features = ["gzip", "tokio"] }
 futures = { workspace = true, optional = true, features = ["std"] }

--- a/noodles-cram/src/codecs/lzma.rs
+++ b/noodles-cram/src/codecs/lzma.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Read, Write};
 
-use xz2::{bufread::XzDecoder, write::XzEncoder};
+use liblzma::{bufread::XzDecoder, write::XzEncoder};
 
 pub fn decode(src: &[u8], dst: &mut [u8]) -> io::Result<()> {
     let mut decoder = XzDecoder::new(src);


### PR DESCRIPTION
Heads up. I couldn't compile noodles with the cram feature in a project due to it linking to older versions of lzma. I had to update xz2-rs to libzma-rs. 

All tests are passing

[https://github.com/portable-network-archive/liblzma-rs](https://github.com/portable-network-archive/liblzma-rs)