### PR TITLE
feat(noodles-bam): expose record codec encode/decode functions

### DIFF
--- a/noodles-bam/CHANGELOG.md
+++ b/noodles-bam/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+  * bam/record/codec: `decode` and `encode` functions are now public.
+
+  * bam/record/codec: Re-export `DecodeError` from the decoder module.
+
 ## 0.85.0 - 2025-12-11
 
 ### Changed

--- a/noodles-bam/src/record/codec.rs
+++ b/noodles-bam/src/record/codec.rs
@@ -1,6 +1,7 @@
-#![doc(hidden)]
+//! BAM record codec for encoding and decoding.
 
 pub mod decoder;
 pub mod encoder;
 
-pub(crate) use self::{decoder::decode, encoder::encode};
+pub use self::decoder::{DecodeError, decode};
+pub use self::encoder::encode;

--- a/noodles-bam/src/record/codec/decoder.rs
+++ b/noodles-bam/src/record/codec/decoder.rs
@@ -1,8 +1,10 @@
 //! BAM record decoder.
 
+#![allow(missing_docs)]
+
 mod bin;
 pub(crate) mod cigar;
-pub mod data;
+pub(crate) mod data;
 mod flags;
 mod mapping_quality;
 mod name;
@@ -97,7 +99,11 @@ impl fmt::Display for DecodeError {
     }
 }
 
-pub(crate) fn decode(src: &mut &[u8], record: &mut RecordBuf) -> Result<(), DecodeError> {
+/// Decodes a BAM record from raw bytes.
+///
+/// The input slice should contain the record data after the 4-byte block size. The slice
+/// reference is advanced past the consumed bytes.
+pub fn decode(src: &mut &[u8], record: &mut RecordBuf) -> Result<(), DecodeError> {
     *record.reference_sequence_id_mut() =
         read_reference_sequence_id(src).map_err(DecodeError::InvalidReferenceSequenceId)?;
 

--- a/noodles-bam/src/record/codec/decoder/data.rs
+++ b/noodles-bam/src/record/codec/decoder/data.rs
@@ -1,4 +1,4 @@
-pub mod field;
+pub(crate) mod field;
 
 pub(crate) use self::field::read_field;
 

--- a/noodles-bam/src/record/codec/decoder/data/field.rs
+++ b/noodles-bam/src/record/codec/decoder/data/field.rs
@@ -11,6 +11,7 @@ use self::{tag::read_tag, ty::read_type};
 
 /// An error when a raw BAM record data field fails to parse.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 pub enum DecodeError {
     /// The tag is invalid.
     InvalidTag(tag::DecodeError),

--- a/noodles-bam/src/record/codec/encoder.rs
+++ b/noodles-bam/src/record/codec/encoder.rs
@@ -1,5 +1,7 @@
 //! BAM record encoder.
 
+#![allow(missing_docs)]
+
 mod bin;
 mod cigar;
 pub mod data;
@@ -62,7 +64,10 @@ impl fmt::Display for EncodeError {
     }
 }
 
-pub(crate) fn encode<R>(dst: &mut Vec<u8>, header: &sam::Header, record: &R) -> io::Result<()>
+/// Encodes a record as raw BAM record data.
+///
+/// The record is encoded without the leading 4-byte block size.
+pub fn encode<R>(dst: &mut Vec<u8>, header: &sam::Header, record: &R) -> io::Result<()>
 where
     R: Record + ?Sized,
 {


### PR DESCRIPTION
## Summary

Expose the `decode` and `encode` functions in `noodles_bam::record::codec` as public API.

## Motivation

These functions enable direct byte-level manipulation of BAM records, which is useful for:
- Parallel BAM processing pipelines that decompress BGZF blocks independently
- Custom serialization workflows that need to encode/decode records without the 4-byte block_size prefix
- Performance-critical applications that bypass the standard reader/writer abstractions

## Changes

- Remove `#![doc(hidden)]` from the codec module
- Change `decode` function visibility from `pub(crate)` to `pub`
- Change `encode` function visibility from `pub(crate)` to `pub`
- Re-export `DecodeError` for proper error handling
- Add documentation for both functions

## API

```rust
/// Decodes a BAM record from raw bytes.
///
/// The input slice should contain the record data after the 4-byte block size.
/// The slice reference is advanced past the consumed bytes.
pub fn decode(src: &mut &[u8], record: &mut RecordBuf) -> Result<(), DecodeError>

/// Encodes a record as raw BAM record data.
///
/// The record is encoded without the leading 4-byte block size.
pub fn encode<R>(dst: &mut Vec<u8>, header: &Header, record: &R) -> io::Result<()>
where
    R: Record + ?Sized
```