### PR TITLE
feat(vcf): add vcf_filter example for quality-based filtering

### DIFF
--- a/noodles-vcf/examples/vcf_filter.rs
+++ b/noodles-vcf/examples/vcf_filter.rs
@@ -1,0 +1,51 @@
+//! Filters VCF records by quality score.
+//!
+//! This example demonstrates how to filter VCF records based on a minimum quality score
+//! threshold. Records with a quality score below the threshold are excluded from the output.
+//!
+//! The result is similar to using `bcftools view -i 'QUAL>=threshold' <src>`.
+
+use std::{
+    env,
+    fs::File,
+    io::{self, BufReader},
+};
+
+use noodles_vcf as vcf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = env::args().skip(1);
+    
+    let src = args.next().expect("missing src");
+    let min_quality: f32 = args
+        .next()
+        .expect("missing minimum quality threshold")
+        .parse()
+        .expect("invalid quality threshold");
+
+    let mut reader = File::open(src)
+        .map(BufReader::new)
+        .map(vcf::io::Reader::new)?;
+
+    let header = reader.read_header()?;
+
+    let stdout = io::stdout().lock();
+    let mut writer = vcf::io::Writer::new(stdout);
+
+    writer.write_header(&header)?;
+
+    for result in reader.records() {
+        let record = result?;
+        
+        // Filter by quality score
+        if let Some(quality_score) = record.quality_score() {
+            if let Some(score) = quality_score.value() {
+                if score >= min_quality {
+                    writer.write_record(&header, &record)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Adds a new vcf_filter example demonstrating how to filter VCF records based on quality score thresholds. This is a common operation in variant calling pipelines for quality control.

Usage: cargo run --release --example vcf_filter input.vcf 30.0 > filtered.vcf

Changes:
- Added noodles-vcf/examples/vcf_filter.rs
- Demonstrates quality-based filtering (common genomics QC operation)
- Follows existing example patterns (vcf_view, vcf_count, etc.)