### PR TITLE
feat(bgzf): add position tracking to MultithreadedWriter

### DIFF
--- a/noodles-bgzf/src/io.rs
+++ b/noodles-bgzf/src/io.rs
@@ -13,8 +13,8 @@ pub mod writer;
 pub(crate) use self::block::Block;
 pub use self::{
     buf_read::BufRead, indexed_reader::IndexedReader, multithreaded_reader::MultithreadedReader,
-    multithreaded_writer::MultithreadedWriter, read::Read, reader::Reader, seek::Seek,
-    writer::Writer,
+    multithreaded_writer::{BlockInfo, BlockInfoRx, MultithreadedWriter},
+    read::Read, reader::Reader, seek::Seek, writer::Writer,
 };
 
 #[cfg(test)]
@@ -103,6 +103,62 @@ mod tests {
         reader.read_to_end(&mut buf)?;
 
         assert_eq!(buf, b"noodles-bgzf");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_multithreaded_position_tracking() -> io::Result<()> {
+        use std::num::NonZero;
+
+        let mut writer = multithreaded_writer::Builder::default()
+            .set_worker_count(NonZero::new(2).unwrap())
+            .build_from_writer(Vec::new());
+
+        // Get the receiver before writing
+        let rx = writer.block_info_receiver().unwrap().clone();
+
+        // Initial state
+        assert_eq!(writer.position(), 0);
+        assert_eq!(writer.current_block_number(), 0);
+        assert_eq!(writer.blocks_written(), 0);
+        assert_eq!(writer.buffer_offset(), 0);
+
+        // Write first block
+        writer.write_all(b"hello")?;
+        assert_eq!(writer.buffer_offset(), 5);
+        writer.flush()?;
+        assert_eq!(writer.current_block_number(), 1);
+        assert_eq!(writer.buffer_offset(), 0);
+
+        // Write second block
+        writer.write_all(b"world")?;
+        writer.flush()?;
+        assert_eq!(writer.current_block_number(), 2);
+
+        // Finish to ensure all blocks are written
+        let _data = writer.finish()?;
+
+        // Collect block info
+        let mut block_infos: Vec<_> = rx.try_iter().collect();
+        block_infos.sort_by_key(|b| b.block_number);
+
+        // Should have 2 blocks
+        assert_eq!(block_infos.len(), 2);
+
+        // First block
+        assert_eq!(block_infos[0].block_number, 0);
+        assert_eq!(block_infos[0].compressed_start, 0);
+        assert_eq!(block_infos[0].uncompressed_size, 5);
+        assert!(block_infos[0].compressed_size > 0);
+
+        // Second block starts after first
+        assert_eq!(block_infos[1].block_number, 1);
+        assert_eq!(
+            block_infos[1].compressed_start,
+            block_infos[0].compressed_size as u64
+        );
+        assert_eq!(block_infos[1].uncompressed_size, 5);
 
         Ok(())
     }

--- a/noodles-bgzf/src/io.rs
+++ b/noodles-bgzf/src/io.rs
@@ -12,9 +12,14 @@ pub mod writer;
 
 pub(crate) use self::block::Block;
 pub use self::{
-    buf_read::BufRead, indexed_reader::IndexedReader, multithreaded_reader::MultithreadedReader,
+    buf_read::BufRead,
+    indexed_reader::IndexedReader,
+    multithreaded_reader::MultithreadedReader,
     multithreaded_writer::{BlockInfo, BlockInfoRx, MultithreadedWriter},
-    read::Read, reader::Reader, seek::Seek, writer::Writer,
+    read::Read,
+    reader::Reader,
+    seek::Seek,
+    writer::Writer,
 };
 
 #[cfg(test)]

--- a/noodles-bgzf/src/io/multithreaded_writer.rs
+++ b/noodles-bgzf/src/io/multithreaded_writer.rs
@@ -7,8 +7,8 @@ use std::{
     mem,
     num::NonZero,
     sync::{
-        atomic::{AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU64, Ordering},
     },
     thread::{self, JoinHandle},
 };

--- a/noodles-bgzf/src/io/multithreaded_writer.rs
+++ b/noodles-bgzf/src/io/multithreaded_writer.rs
@@ -6,6 +6,10 @@ use std::{
     io::{self, Write},
     mem,
     num::NonZero,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     thread::{self, JoinHandle},
 };
 
@@ -20,8 +24,29 @@ type BufferedTx = Sender<io::Result<FrameParts>>;
 type BufferedRx = Receiver<io::Result<FrameParts>>;
 type DeflateTx = Sender<(Bytes, BufferedTx)>;
 type DeflateRx = Receiver<(Bytes, BufferedTx)>;
-type WriteTx = Sender<BufferedRx>;
-type WriteRx = Receiver<BufferedRx>;
+type WriteTx = Sender<(BufferedRx, u64)>; // Now includes block_number
+type WriteRx = Receiver<(BufferedRx, u64)>;
+type BlockInfoTx = Sender<BlockInfo>;
+
+/// Block completion info sent from writer thread.
+///
+/// This enables building indexes while using multi-threaded compression:
+/// cache index entries with their block number, then resolve positions
+/// when the block completion notification is received.
+#[derive(Debug, Clone, Copy)]
+pub struct BlockInfo {
+    /// The block number (0-indexed, assigned when block is sent for compression).
+    pub block_number: u64,
+    /// The compressed file position where this block starts.
+    pub compressed_start: u64,
+    /// The size of the compressed block (including header and trailer).
+    pub compressed_size: usize,
+    /// The size of the uncompressed data in this block.
+    pub uncompressed_size: usize,
+}
+
+/// Receiver for block completion notifications.
+pub type BlockInfoRx = Receiver<BlockInfo>;
 
 enum State<W> {
     Running {
@@ -29,6 +54,7 @@ enum State<W> {
         deflater_handles: Vec<JoinHandle<()>>,
         write_tx: WriteTx,
         deflate_tx: DeflateTx,
+        block_info_rx: BlockInfoRx,
     },
     Done,
 }
@@ -36,12 +62,23 @@ enum State<W> {
 /// A multithreaded BGZF writer.
 ///
 /// This is much more basic than [`super::Writer`] but uses a thread pool to compress block data.
+///
+/// # Position Tracking
+///
+/// This writer supports position tracking for building BAM indexes during multi-threaded
+/// compression. Use [`block_info_receiver`](Self::block_info_receiver) to receive
+/// notifications when blocks are written to the output, then resolve cached index entries
+/// with their final compressed positions.
 pub struct MultithreadedWriter<W>
 where
     W: Write + Send + 'static,
 {
     state: State<W>,
     buf: BytesMut,
+    // Block tracking for indexing
+    current_block_number: u64,
+    position: Arc<AtomicU64>,
+    blocks_written: Arc<AtomicU64>,
 }
 
 impl<W> MultithreadedWriter<W>
@@ -104,6 +141,7 @@ where
                 mut deflater_handles,
                 write_tx,
                 deflate_tx,
+                block_info_rx: _,
             } => {
                 drop(deflate_tx);
 
@@ -139,13 +177,79 @@ where
 
         let (buffered_tx, buffered_rx) = crossbeam_channel::bounded(1);
 
-        write_tx.send(buffered_rx).unwrap();
+        // Include block number with the send
+        write_tx
+            .send((buffered_rx, self.current_block_number))
+            .unwrap();
+        self.current_block_number += 1;
 
         let src = self.buf.split().freeze();
         let message = (src, buffered_tx);
         deflate_tx.send(message).unwrap();
 
         Ok(())
+    }
+
+    /// Returns a receiver for block completion notifications.
+    ///
+    /// Use this for building indexes: cache index entries with their block number,
+    /// then resolve positions when the block completion notification is received.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io::{self, Write};
+    /// use noodles_bgzf as bgzf;
+    ///
+    /// let mut writer = bgzf::io::MultithreadedWriter::new(io::sink());
+    ///
+    /// // Get the receiver before writing
+    /// let rx = writer.block_info_receiver().unwrap().clone();
+    ///
+    /// // Write data
+    /// writer.write_all(b"hello")?;
+    /// writer.flush()?;
+    ///
+    /// // Check for block completions (non-blocking)
+    /// while let Ok(info) = rx.try_recv() {
+    ///     println!("Block {} written at position {}", info.block_number, info.compressed_start);
+    /// }
+    /// # Ok::<_, io::Error>(())
+    /// ```
+    pub fn block_info_receiver(&self) -> Option<&BlockInfoRx> {
+        match &self.state {
+            State::Running { block_info_rx, .. } => Some(block_info_rx),
+            State::Done => None,
+        }
+    }
+
+    /// Returns the current block number (the next block to be written).
+    ///
+    /// This is incremented each time data is flushed (a new block is sent for compression).
+    pub fn current_block_number(&self) -> u64 {
+        self.current_block_number
+    }
+
+    /// Returns the number of blocks fully written to the output.
+    ///
+    /// This lags behind `current_block_number` while blocks are being compressed
+    /// and written.
+    pub fn blocks_written(&self) -> u64 {
+        self.blocks_written.load(Ordering::Acquire)
+    }
+
+    /// Returns the current compressed file position.
+    ///
+    /// This is the total number of bytes written to the underlying writer.
+    pub fn position(&self) -> u64 {
+        self.position.load(Ordering::Acquire)
+    }
+
+    /// Returns the current offset in the staging buffer (uncompressed bytes).
+    ///
+    /// This is the number of bytes written since the last flush.
+    pub fn buffer_offset(&self) -> usize {
+        self.buf.len()
     }
 }
 
@@ -184,21 +288,46 @@ where
     }
 }
 
-fn spawn_writer<W>(mut writer: W, write_rx: WriteRx) -> JoinHandle<io::Result<W>>
+fn spawn_writer<W>(
+    mut writer: W,
+    write_rx: WriteRx,
+    position: Arc<AtomicU64>,
+    blocks_written: Arc<AtomicU64>,
+    block_info_tx: BlockInfoTx,
+) -> JoinHandle<io::Result<W>>
 where
     W: Write + Send + 'static,
 {
     use super::writer::{BGZF_EOF, write_frame};
 
     thread::spawn(move || {
-        while let Ok(buffered_rx) = write_rx.recv() {
+        while let Ok((buffered_rx, block_number)) = write_rx.recv() {
             if let Ok(result) = buffered_rx.recv() {
                 let (compressed_data, crc32, uncompressed_size) = result?;
-                write_frame(&mut writer, &compressed_data, crc32, uncompressed_size)?;
+
+                // Capture position before writing
+                let compressed_start = position.load(Ordering::Acquire);
+
+                // Write the block
+                let block_size =
+                    write_frame(&mut writer, &compressed_data, crc32, uncompressed_size)?;
+
+                // Update position after writing
+                position.fetch_add(block_size as u64, Ordering::Release);
+                blocks_written.fetch_add(1, Ordering::Release);
+
+                // Send block completion info
+                let _ = block_info_tx.send(BlockInfo {
+                    block_number,
+                    compressed_start,
+                    compressed_size: block_size,
+                    uncompressed_size,
+                });
             }
         }
 
         writer.write_all(&BGZF_EOF)?;
+        position.fetch_add(BGZF_EOF.len() as u64, Ordering::Release);
 
         Ok(writer)
     })

--- a/noodles-bgzf/src/io/multithreaded_writer/builder.rs
+++ b/noodles-bgzf/src/io/multithreaded_writer/builder.rs
@@ -1,7 +1,7 @@
 use std::{
     io::Write,
     num::NonZero,
-    sync::{atomic::AtomicU64, Arc},
+    sync::{Arc, atomic::AtomicU64},
 };
 
 use bytes::BytesMut;

--- a/noodles-bgzf/src/io/multithreaded_writer/builder.rs
+++ b/noodles-bgzf/src/io/multithreaded_writer/builder.rs
@@ -1,4 +1,8 @@
-use std::{io::Write, num::NonZero};
+use std::{
+    io::Write,
+    num::NonZero,
+    sync::{atomic::AtomicU64, Arc},
+};
 
 use bytes::BytesMut;
 
@@ -62,10 +66,23 @@ impl Builder {
 
         let worker_count = self.worker_count.get();
 
+        // Position tracking for indexing support
+        let position = Arc::new(AtomicU64::new(0));
+        let blocks_written = Arc::new(AtomicU64::new(0));
+
+        // Block info channel (unbounded - writer shouldn't block)
+        let (block_info_tx, block_info_rx) = crossbeam_channel::unbounded();
+
         let (write_tx, write_rx) = crossbeam_channel::bounded(worker_count);
         let (deflate_tx, deflate_rx) = crossbeam_channel::bounded(worker_count);
 
-        let writer_handle = spawn_writer(writer, write_rx);
+        let writer_handle = spawn_writer(
+            writer,
+            write_rx,
+            Arc::clone(&position),
+            Arc::clone(&blocks_written),
+            block_info_tx,
+        );
         let deflater_handles =
             spawn_deflaters(self.compression_level, self.worker_count, deflate_rx);
 
@@ -75,8 +92,12 @@ impl Builder {
                 deflater_handles,
                 write_tx,
                 deflate_tx,
+                block_info_rx,
             },
             buf: BytesMut::new(),
+            current_block_number: 0,
+            position,
+            blocks_written,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds position tracking to `MultithreadedWriter` to enable building BAM indexes during multi-threaded compression.

## Motivation

When using `MultithreadedWriter` for parallel BAM compression, there's currently no way to determine the compressed file positions needed for BAI/CSI index construction. The standard `Writer` allows position tracking through its synchronous API, but `MultithreadedWriter` compresses and writes blocks asynchronously, making position correlation difficult.

This change enables building indexes during multi-threaded writes by:
1. Assigning sequential block numbers when blocks are sent for compression
2. Sending notifications (via channel) when blocks complete with their final compressed positions
3. Allowing callers to cache index entries with block numbers, then resolve positions when notifications arrive

## Use Case

This supports the parallel BAM processing pipeline I'm building (related to #364). The workflow:

1. Process records, caching index entries with `(block_number, uncompressed_offset)`
2. Flush blocks to compression (receive block number)
3. Receive `BlockInfo` notifications when blocks are written
4. Resolve cached index entries to final `(compressed_position, uncompressed_offset)` virtual offsets

## New Public API

- `BlockInfo` - struct with `block_number`, `compressed_start`, `compressed_size`, `uncompressed_size`
- `BlockInfoRx` - type alias for the receiver channel
- `block_info_receiver()` - get the notification receiver
- `current_block_number()` - next block number to be assigned
- `blocks_written()` - count of blocks fully written
- `position()` - current compressed file position
- `buffer_offset()` - bytes in staging buffer since last flush

## Alternatives Considered

- **Post-hoc index building**: Requires re-reading the BAM file after writing, doubling I/O for large files
- **Single-threaded Writer**: Works but sacrifices the compression parallelism that `MultithreadedWriter` provides

## Test Plan

- [x] Added unit test covering position tracking through multiple blocks
- [x] Existing tests pass