### PR TITLE
Fix CRAI writing bug

### DIFF
--- a/noodles-cram/src/crai/fs.rs
+++ b/noodles-cram/src/crai/fs.rs
@@ -44,6 +44,6 @@ pub fn write<P>(dst: P, index: &[Record]) -> std::io::Result<()>
 where
     P: AsRef<Path>,
 {
-    let mut writer = File::open(dst).map(Writer::new)?;
+    let mut writer = File::create(dst).map(Writer::new)?;
     writer.write_index(index)
 }


### PR DESCRIPTION
CRAM index writing is broken as in the following minimal example:

```
use noodles::cram::crai;
use noodles::core::position;

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let index = vec![crai::Record::new(
            Some(0),
            position::Position::new(1234),
            6765,
            17711,
            233,
            317811,
        )];
    crai::fs::write("sample.cram.crai", &index)?;
    Ok(())
}
```

Result:
If the file doesn't exist: `Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }`
If the file does: `Error: Os { code: 9, kind: Uncategorized, message: "Bad file descriptor" }`

Because it's being opened read-only.

File::create instead of File::open restores the expected behavior

