### PR TITLE
Implement nibble-based decoding of BAM sequence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ reqwest = { version = "0.13.1", default-features = false, features = ["json", "s
 serde = { version = "1.0.136", features = ["derive"] }
 tokio = "1.10.0"
 url = "2.2.2"
+criterion = { version = "0.5", default-features = false }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/noodles-bam/Cargo.toml
+++ b/noodles-bam/Cargo.toml
@@ -34,6 +34,7 @@ noodles-csi = { path = "../noodles-csi", version = "0.55.0" }
 noodles-sam = { path = "../noodles-sam", version = "0.84.0" }
 
 [dev-dependencies]
+criterion.workspace = true
 flate2.workspace = true
 noodles-sam = { path = "../noodles-sam", version = "0.84.0", features = ["async"] }
 tokio = { workspace = true, features = ["io-std", "macros", "rt-multi-thread"] }
@@ -43,6 +44,10 @@ workspace = true
 
 [package.metadata.docs.rs]
 features = ["async"]
+
+[[bench]]
+name = "read_record"
+harness = false
 
 [[example]]
 name = "bam_count_async"

--- a/noodles-bam/benches/read_record.rs
+++ b/noodles-bam/benches/read_record.rs
@@ -1,0 +1,196 @@
+use std::hint::black_box;
+use std::num::NonZero;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use noodles_bam as bam;
+use noodles_core::Position;
+use noodles_sam::{
+    self as sam,
+    alignment::{
+        RecordBuf,
+        io::Write as _,
+        record::{
+            Flags, MappingQuality,
+            cigar::{Op, op::Kind},
+            data::field::Tag,
+        },
+        record_buf::{Cigar, Sequence, data::field::Value},
+    },
+    header::record::value::{Map, map::ReferenceSequence},
+};
+
+const NUM_RECORDS: usize = 10_000;
+
+fn build_cigar(i: usize, read_len: usize) -> Cigar {
+    let bucket = i % 100;
+
+    if bucket < 85 {
+        // 85%: perfect match
+        Cigar::from(vec![Op::new(Kind::Match, read_len)])
+    } else if bucket < 90 {
+        // 5%: 5' soft clip
+        Cigar::from(vec![
+            Op::new(Kind::SoftClip, 5),
+            Op::new(Kind::Match, read_len - 5),
+        ])
+    } else if bucket < 95 {
+        // 5%: 3' soft clip
+        Cigar::from(vec![
+            Op::new(Kind::Match, read_len - 5),
+            Op::new(Kind::SoftClip, 5),
+        ])
+    } else if bucket < 98 {
+        // 3%: single insertion
+        let half = read_len / 2;
+        Cigar::from(vec![
+            Op::new(Kind::Match, half),
+            Op::new(Kind::Insertion, 1),
+            Op::new(Kind::Match, read_len - half - 1),
+        ])
+    } else {
+        // 2%: single deletion
+        let half = read_len / 2;
+        Cigar::from(vec![
+            Op::new(Kind::Match, half),
+            Op::new(Kind::Deletion, 1),
+            Op::new(Kind::Match, read_len - half),
+        ])
+    }
+}
+
+fn build_md(i: usize, read_len: usize) -> Value {
+    let bucket = i % 100;
+
+    if bucket < 85 {
+        Value::from(format!("{read_len}"))
+    } else if bucket < 95 {
+        // soft clips don't appear in MD
+        let matched = read_len - 5;
+        Value::from(format!("{matched}"))
+    } else if bucket < 98 {
+        // insertion: MD reflects only ref-consuming ops
+        let half = read_len / 2;
+        Value::from(format!("{}{}", half, read_len - half - 1))
+    } else {
+        // deletion
+        let half = read_len / 2;
+        Value::from(format!("{half}^A{half}"))
+    }
+}
+
+fn build_mate_cigar(i: usize, read_len: usize) -> Value {
+    let bucket = i % 100;
+
+    if bucket < 90 {
+        Value::from(format!("{read_len}M"))
+    } else {
+        Value::from(format!("5S{}M", read_len - 5))
+    }
+}
+
+/// Generates a BGZF-compressed BAM byte stream with `n` records of `read_len` bases each,
+/// using realistic field values representative of BWA-MEM paired-end WGS output.
+fn build_bam_data(n: usize, read_len: usize) -> (Vec<u8>, sam::Header) {
+    let header = sam::Header::builder()
+        .add_reference_sequence(
+            "chr1",
+            Map::<ReferenceSequence>::new(NonZero::new(249_250_621).unwrap()),
+        )
+        .build();
+
+    let mut writer = bam::io::Writer::new(Vec::new());
+    writer.write_header(&header).unwrap();
+
+    let seq = Sequence::from(
+        (0..read_len)
+            .map(|i| b"ACGTACGT"[i % 8])
+            .collect::<Vec<u8>>(),
+    );
+    let qual: Vec<u8> = (0..read_len).map(|i| (20 + (i % 21)) as u8).collect();
+
+    let flags = Flags::SEGMENTED
+        | Flags::PROPERLY_SEGMENTED
+        | Flags::MATE_REVERSE_COMPLEMENTED
+        | Flags::FIRST_SEGMENT;
+
+    let mq_tag = Tag::new(b'M', b'Q');
+
+    for i in 0..n {
+        let pos = 1 + (i % 100_000);
+        let nm: u8 = if i % 100 >= 98 { 1 } else { 0 };
+
+        let record = RecordBuf::builder()
+            .set_name(format!("HISEQ:1:2103:{i}:81321"))
+            .set_flags(flags)
+            .set_reference_sequence_id(0)
+            .set_alignment_start(Position::try_from(pos).unwrap())
+            .set_mapping_quality(MappingQuality::try_from(60).unwrap())
+            .set_cigar(build_cigar(i, read_len))
+            .set_mate_reference_sequence_id(0)
+            .set_mate_alignment_start(Position::try_from(pos + 300).unwrap())
+            .set_template_length(300)
+            .set_sequence(seq.clone())
+            .set_quality_scores(qual.iter().copied().collect())
+            .set_data(
+                [
+                    (Tag::ALIGNMENT_SCORE, Value::UInt8(read_len as u8)),
+                    (mq_tag, Value::UInt8(60)),
+                    (Tag::EDIT_DISTANCE, Value::UInt8(nm)),
+                    (Tag::ALIGNMENT_HIT_COUNT, Value::UInt8(1)),
+                    (Tag::READ_GROUP, Value::from("SampleA_LibB_Lane3")),
+                    (Tag::MISMATCHED_POSITIONS, build_md(i, read_len)),
+                    (Tag::MATE_CIGAR, build_mate_cigar(i, read_len)),
+                ]
+                .into_iter()
+                .collect(),
+            )
+            .build();
+
+        writer.write_alignment_record(&header, &record).unwrap();
+    }
+
+    writer.try_finish().unwrap();
+    let data = writer.get_ref().get_ref().clone();
+    (data, header)
+}
+
+fn bench_read_record(c: &mut Criterion) {
+    for read_len in [150, 300] {
+        let mut group = c.benchmark_group(format!("{read_len}bp"));
+        let (bam_data, header) = build_bam_data(NUM_RECORDS, read_len);
+        group.throughput(Throughput::Elements(NUM_RECORDS as u64));
+
+        group.bench_function("record_buf", |b| {
+            b.iter(|| {
+                let mut reader = bam::io::Reader::new(bam_data.as_slice());
+                let _ = reader.read_header().unwrap();
+                let mut record = RecordBuf::default();
+                let mut n = 0u64;
+                while reader.read_record_buf(&header, &mut record).unwrap() > 0 {
+                    black_box(&record);
+                    n += 1;
+                }
+                n
+            })
+        });
+
+        group.bench_function("record_lazy", |b| {
+            b.iter(|| {
+                let mut reader = bam::io::Reader::new(bam_data.as_slice());
+                let _ = reader.read_header().unwrap();
+                let mut record = bam::Record::default();
+                let mut n = 0u64;
+                while reader.read_record(&mut record).unwrap() > 0 {
+                    black_box(&record);
+                    n += 1;
+                }
+                n
+            })
+        });
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_read_record);
+criterion_main!(benches);

--- a/noodles-bam/src/record/codec/decoder/sequence.rs
+++ b/noodles-bam/src/record/codec/decoder/sequence.rs
@@ -29,6 +29,22 @@ impl fmt::Display for DecodeError {
     }
 }
 
+// Lookup table mapping each packed byte to its two decoded bases. BAM encodes sequences with
+// two 4-bit base codes per byte (high nibble first).
+const NIBBLE_PAIRS: [[u8; 2]; 256] = {
+    const BASES: [u8; 16] = *b"=ACMGRSVTWYHKDBN";
+
+    let mut table = [[0u8; 2]; 256];
+    let mut i = 0;
+
+    while i < 256 {
+        table[i] = [BASES[i >> 4], BASES[i & 0xf]];
+        i += 1;
+    }
+
+    table
+};
+
 pub(super) fn read_length(src: &mut &[u8]) -> Result<usize, DecodeError> {
     read_u32_le(src).and_then(|n| usize::try_from(n).map_err(DecodeError::InvalidLength))
 }
@@ -46,9 +62,7 @@ pub(super) fn read_sequence(
 
     *src = rest;
 
-    let bases = buf
-        .iter()
-        .flat_map(|&b| [decode_base(b >> 4), decode_base(b)]);
+    let bases = buf.iter().flat_map(|&b| NIBBLE_PAIRS[b as usize]);
 
     let dst = sequence.as_mut();
     dst.clear();
@@ -56,28 +70,6 @@ pub(super) fn read_sequence(
     dst.truncate(base_count);
 
     Ok(())
-}
-
-fn decode_base(n: u8) -> u8 {
-    match n & 0x0f {
-        0 => b'=',
-        1 => b'A',
-        2 => b'C',
-        3 => b'M',
-        4 => b'G',
-        5 => b'R',
-        6 => b'S',
-        7 => b'V',
-        8 => b'T',
-        9 => b'W',
-        10 => b'Y',
-        11 => b'H',
-        12 => b'K',
-        13 => b'D',
-        14 => b'B',
-        15 => b'N',
-        _ => unreachable!(),
-    }
 }
 
 fn read_u32_le(src: &mut &[u8]) -> Result<u32, DecodeError> {
@@ -125,22 +117,12 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_base() {
-        assert_eq!(decode_base(0), b'=');
-        assert_eq!(decode_base(1), b'A');
-        assert_eq!(decode_base(2), b'C');
-        assert_eq!(decode_base(3), b'M');
-        assert_eq!(decode_base(4), b'G');
-        assert_eq!(decode_base(5), b'R');
-        assert_eq!(decode_base(6), b'S');
-        assert_eq!(decode_base(7), b'V');
-        assert_eq!(decode_base(8), b'T');
-        assert_eq!(decode_base(9), b'W');
-        assert_eq!(decode_base(10), b'Y');
-        assert_eq!(decode_base(11), b'H');
-        assert_eq!(decode_base(12), b'K');
-        assert_eq!(decode_base(13), b'D');
-        assert_eq!(decode_base(14), b'B');
-        assert_eq!(decode_base(15), b'N');
+    fn test_nibble_pairs() {
+        let expected = *b"=ACMGRSVTWYHKDBN";
+
+        for (code, base) in expected.iter().enumerate() {
+            assert_eq!(NIBBLE_PAIRS[code << 4][0], *base, "high nibble {code}");
+            assert_eq!(NIBBLE_PAIRS[code][1], *base, "low nibble {code}");
+        }
     }
 }


### PR DESCRIPTION
I've been looking for opportunities to shave time off the path of reading a BAM file into an iterator of RecordBuf.  This is a small focused change, and is internal to how the BAM 4-bit per base encoded sequence is inflated back into a Vec<u8>, using a nibble lookup rather than per-base shift and lookup.

The PR is organized into two commits - the first adds `criterion` as a dev dependency, and then sets up a BAM record decoding benchmark using what I think are fairly realistic short reads with a mixture of Cigars, and a pretty common set of aux tags per record.  The second then implements the nibble-decoding.  It's setup this way to enable easy running of the bench pre/post the change.  Also, if your preference is not to add criterion and/or benches to the repo, it should be easy to cherry-pick just the functional change.

The improvement is small, but real in my hands.  Testing on an aarch64 mac with the included bench I see about a 3% improvement in the overall time for the complete decoding of the BAM record into a RecordBuf.  This obviously doesn't include any I/O or bgzf decompression time - so real world gains will likely be smaller.

@zaeleus I'm more than happy to take feedback and re-work this if you'd like to see it done differently.  Given the small size and limited scope of the functional change I figured a PR would be easier than trying to describe this in an issue first.