### PR TITLE
bgzf: Use libdeflater::Crc when libdeflate feature is enabled

### DIFF
--- a/noodles-bgzf/CHANGELOG.md
+++ b/noodles-bgzf/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+  * bgzf/deflate: Use libdeflate's CRC32 implementation when the `libdeflate`
+    feature is enabled.
+
+    This matches the (de)compressor backend selection and is measurably faster
+    on both x86_64 and aarch64.
+
 ## 0.46.0 - 2026-02-18
 
 ### Changed

--- a/noodles-bgzf/src/deflate.rs
+++ b/noodles-bgzf/src/deflate.rs
@@ -78,10 +78,18 @@ pub(crate) fn encode(src: &[u8], compression_level: i32, dst: &mut Vec<u8>) -> i
     }
 }
 
+#[cfg(not(feature = "libdeflate"))]
 pub(crate) fn crc32(src: &[u8]) -> u32 {
     const START: u32 = 0;
 
     zlib_rs::crc32::crc32(START, src)
+}
+
+#[cfg(feature = "libdeflate")]
+pub(crate) fn crc32(src: &[u8]) -> u32 {
+    let mut crc = libdeflater::Crc::new();
+    crc.update(src);
+    crc.sum()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The block data checksum was previously always computed with flate2::Crc, even when libdeflate was selected for (de)compression. Routing CRC32 through libdeflater::Crc under the same feature matches the codec and is measurably faster on both x86_64 and aarch64. Applies to both the reader frame verification and writer trailer generation paths.

For context I've been spending a good amount of time profiling code that uses noodles to read BAM files.  When profiling on an apple silicon mac it jumped out at me that the time spent in CRC computation on the BAM decompression path seemed really high - in one run on a 1KG wgs BAM I was seeing 92s total for decompression, of which 19s was CRC computation.  

I've benchmarked this change on both apple silicon (which I expect to be comparable to graviton and other aarch64 platforms) and x86 (AVX512 at AWS).  The improvement on aarch64 is dramatic - the libdeflate CRC is 6.6x faster in my hands!  So that 92s decompression shrinks to ~76s.  On x86 it is less dramatic, but the libdeflate CRC is still over 2x faster there, which is still a nice win.

I made the matching change on the compression pathway too for symmetry's sake, although obviously the CRC computation is a much smaller fraction of the total on that path.