### PR TITLE
fasta/io/indexed_reader/builder: Add set_buffer_capacity for small perf gain

### DIFF
--- a/noodles-fasta/src/io/indexed_reader/builder.rs
+++ b/noodles-fasta/src/io/indexed_reader/builder.rs
@@ -10,10 +10,27 @@ use noodles_bgzf as bgzf;
 use super::IndexedReader;
 use crate::fai;
 
+/// Default read buffer capacity (in bytes) for uncompressed inputs.
+///
+/// Chosen empirically: on a multi-GB reference loaded contig-by-contig,
+/// throughput is flat between ~32 KiB and ~256 KiB and ~10% better than
+/// the 8 KiB [`BufReader`] default. 64 KiB is a friendly midpoint that
+/// also matches a typical filesystem block-cache page granularity.
+const DEFAULT_BUFFER_CAPACITY: usize = 64 * 1024;
+
 /// An indexed FASTA reader builder.
-#[derive(Default)]
 pub struct Builder {
     index: Option<fai::Index>,
+    buffer_capacity: usize,
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self {
+            index: None,
+            buffer_capacity: DEFAULT_BUFFER_CAPACITY,
+        }
+    }
 }
 
 impl Builder {
@@ -28,6 +45,32 @@ impl Builder {
     /// ```
     pub fn set_index(mut self, index: fai::Index) -> Self {
         self.index = Some(index);
+        self
+    }
+
+    /// Sets the read buffer capacity (in bytes) for uncompressed inputs.
+    ///
+    /// [`build_from_path`] wraps the opened file in a
+    /// [`BufReader::with_capacity`] of this size. The default is 64 KiB,
+    /// which is friendlier than the 8 KiB [`BufReader`] default for
+    /// streaming long contiguous regions, e.g. loading a full chromosome
+    /// via [`IndexedReader::read_sequence`].
+    ///
+    /// Ignored for BGZF-compressed inputs (`.gz`, `.bgz`): the BGZF
+    /// reader consumes block-sized chunks directly from the file and an
+    /// outer buffer provides no measurable benefit.
+    ///
+    /// [`build_from_path`]: Self::build_from_path
+    /// [`IndexedReader::read_sequence`]: super::IndexedReader::read_sequence
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_fasta::io::indexed_reader::Builder;
+    /// let builder = Builder::default().set_buffer_capacity(128 * 1024);
+    /// ```
+    pub fn set_buffer_capacity(mut self, capacity: usize) -> Self {
+        self.buffer_capacity = capacity;
         self
     }
 
@@ -59,7 +102,7 @@ impl Builder {
                 .build_from_path(src)
                 .map(crate::io::BufReader::Bgzf)?,
             _ => File::open(src)
-                .map(BufReader::new)
+                .map(|file| BufReader::with_capacity(self.buffer_capacity, file))
                 .map(crate::io::BufReader::Uncompressed)?,
         };
 
@@ -117,5 +160,16 @@ mod tests {
     #[test]
     fn test_build_index_src() {
         assert_eq!(build_index_src("ref.fa"), PathBuf::from("ref.fa.fai"));
+    }
+
+    #[test]
+    fn test_default_buffer_capacity() {
+        assert_eq!(Builder::default().buffer_capacity, DEFAULT_BUFFER_CAPACITY);
+    }
+
+    #[test]
+    fn test_set_buffer_capacity() {
+        let builder = Builder::default().set_buffer_capacity(128 * 1024);
+        assert_eq!(builder.buffer_capacity, 128 * 1024);
     }
 }


### PR DESCRIPTION
The uncompressed path of `Builder::build_from_path` previously wrapped the opened file in `BufReader::new`, which uses the std 8 KiB default capacity. When loading whole contigs via `read_sequence`, this ends up making tens of thousands of `read` syscalls per chromosome on a multi-GB reference.

The savings from this change are, realistically, quite small.  In my hands on an M1 mac, it does shave about 10% off with a buffer in the 32-128kb range, but in absolute terms, once the FASTA is in page cache, that's like 0.1-0.2s, so I'll understand if you don't think that's worthwhile.

This change:

  * adds `Builder::set_buffer_capacity` for callers that want to tune the buffer size, and
  * raises the default to 64 KiB, a friendly midpoint that captures most of the win without regressing on references with many tiny decoy/alt contigs (where bigger buffers waste read-ahead).

The BGZF branch is untouched: BGZF reads block-sized chunks directly from the file, and an outer `BufReader` was confirmed (separate bench) to provide no measurable benefit there.

I'd also be happy to make the buffer_size an Option and default to None (with the default then being the old behavior), or any other setup you'd prefer.