### PR TITLE
sam,bam: document quality score encoding

### DIFF
--- a/noodles-bam/src/record/quality_scores.rs
+++ b/noodles-bam/src/record/quality_scores.rs
@@ -3,6 +3,8 @@ use std::io;
 use noodles_sam as sam;
 
 /// BAM record quality scores.
+///
+/// The wrapped bytes are raw phred values (no encoding offset).
 #[derive(Debug, Eq, PartialEq)]
 pub struct QualityScores<'a>(&'a [u8]);
 

--- a/noodles-sam/src/alignment/record/quality_scores.rs
+++ b/noodles-sam/src/alignment/record/quality_scores.rs
@@ -9,6 +9,8 @@ pub trait QualityScores {
     fn len(&self) -> usize;
 
     /// Returns an iterator over scores.
+    ///
+    /// Yields normalized phred values; implementations strip any encoding offset.
     fn iter(&self) -> Box<dyn Iterator<Item = io::Result<u8>> + '_>;
 }
 

--- a/noodles-sam/src/record/quality_scores.rs
+++ b/noodles-sam/src/record/quality_scores.rs
@@ -1,6 +1,9 @@
 use std::io;
 
 /// SAM record quality scores.
+///
+/// The wrapped bytes are Phred+33-encoded, as written in the QUAL field.
+/// See [`crate::alignment::record::QualityScores`] for normalized phred values.
 #[derive(Debug, Eq, PartialEq)]
 pub struct QualityScores<'a>(&'a [u8]);
 


### PR DESCRIPTION
The `QualityScores` types in `noodles-sam` and `noodles-bam` wrap raw bytes
with format-dependent meaning: SAM is Phred+33-encoded, BAM is raw phred.
The `sam::alignment::record::QualityScores` trait normalizes both. None of
this was in rustdoc.

Adds short clarifications to the two struct docs and the trait method doc.
No behavior changes.

Closes #345.