### PR TITLE
Filter CRAM queries by CRAI interval

### DIFF
--- a/noodles-cram/src/async/io/reader/query.rs
+++ b/noodles-cram/src/async/io/reader/query.rs
@@ -48,12 +48,8 @@ where
         loop {
             match ctx.records.next() {
                 Some(r) => {
-                    if let (Some(start), Some(end)) = (r.alignment_start(), r.alignment_end()) {
-                        let alignment_interval = (start..=end).into();
-
-                        if ctx.interval.intersects(alignment_interval) {
-                            return Ok(Some((r, ctx)));
-                        }
+                    if intersects(&r, ctx.reference_sequence_id, ctx.interval) {
+                        return Ok(Some((r, ctx)));
                     }
                 }
                 None => match read_next_container(&mut ctx).await {
@@ -72,7 +68,7 @@ where
 {
     let index_record = ctx.index.next()?;
 
-    if index_record.reference_sequence_id() != Some(ctx.reference_sequence_id) {
+    if !intersects_index_record(index_record, ctx.reference_sequence_id, ctx.interval) {
         return Some(Ok(()));
     }
 
@@ -97,44 +93,146 @@ where
         Err(e) => return Some(Err(e)),
     };
 
-    let records = container
-        .slices()
-        .map(|result| {
-            let slice = result?;
+    let slice = match container.slice(index_record.landmark()) {
+        Ok(slice) => slice,
+        Err(e) => return Some(Err(e)),
+    };
 
-            let (core_data_src, external_data_srcs) = slice.decode_blocks()?;
+    let (core_data_src, external_data_srcs) = match slice.decode_blocks() {
+        Ok(blocks) => blocks,
+        Err(e) => return Some(Err(e)),
+    };
 
-            slice
-                .records(
-                    ctx.reader.reference_sequence_repository.clone(),
-                    ctx.header,
-                    &compression_header,
-                    &core_data_src,
-                    &external_data_srcs,
-                )
-                .and_then(|records| {
-                    records
-                        .into_iter()
-                        .map(|record| {
-                            sam::alignment::RecordBuf::try_from_alignment_record(
-                                ctx.header, &record,
-                            )
-                        })
-                        .collect::<io::Result<Vec<_>>>()
+    let records = slice
+        .records(
+            ctx.reader.reference_sequence_repository.clone(),
+            ctx.header,
+            &compression_header,
+            &core_data_src,
+            &external_data_srcs,
+        )
+        .and_then(|records| {
+            records
+                .into_iter()
+                .map(|record| {
+                    sam::alignment::RecordBuf::try_from_alignment_record(ctx.header, &record)
                 })
-        })
-        .collect::<Result<Vec<_>, _>>();
+                .collect::<io::Result<Vec<_>>>()
+        });
 
     let records = match records {
         Ok(records) => records,
         Err(e) => return Some(Err(e)),
     };
 
-    ctx.records = records
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>()
-        .into_iter();
+    ctx.records = records.into_iter();
 
     Some(Ok(()))
+}
+
+fn intersects(
+    record: &sam::alignment::RecordBuf,
+    reference_sequence_id: usize,
+    region_interval: Interval,
+) -> bool {
+    match (
+        record.reference_sequence_id(),
+        record.alignment_start(),
+        record.alignment_end(),
+    ) {
+        (Some(id), Some(start), Some(end)) if id == reference_sequence_id => {
+            let alignment_interval = (start..=end).into();
+            region_interval.intersects(alignment_interval)
+        }
+        _ => false,
+    }
+}
+
+fn intersects_index_record(
+    record: &crai::Record,
+    reference_sequence_id: usize,
+    region_interval: Interval,
+) -> bool {
+    if record.reference_sequence_id() != Some(reference_sequence_id) {
+        return false;
+    }
+
+    let Some(start) = record.alignment_start() else {
+        return false;
+    };
+
+    let Some(end) = start.checked_add(record.alignment_span().saturating_sub(1)) else {
+        return true;
+    };
+
+    region_interval.intersects((start..=end).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use noodles_core::Position;
+    use noodles_sam::alignment::{
+        record::cigar::{Op, op::Kind},
+        record_buf::Cigar,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_intersects() {
+        let record = build_record(0, 8, 5);
+        let interval =
+            Interval::from(Position::try_from(10).unwrap()..=Position::try_from(13).unwrap());
+
+        assert!(intersects(&record, 0, interval));
+    }
+
+    #[test]
+    fn test_intersects_with_different_reference_sequence() {
+        let record = build_record(1, 8, 5);
+        let interval =
+            Interval::from(Position::try_from(10).unwrap()..=Position::try_from(13).unwrap());
+
+        assert!(!intersects(&record, 0, interval));
+    }
+
+    #[test]
+    fn test_intersects_index_record() {
+        let record = crai::Record::new(Some(0), Position::new(8), 5, 13, 21, 34);
+        let interval =
+            Interval::from(Position::try_from(10).unwrap()..=Position::try_from(13).unwrap());
+
+        assert!(intersects_index_record(&record, 0, interval));
+    }
+
+    #[test]
+    fn test_intersects_index_record_with_nonoverlapping_interval() {
+        let record = crai::Record::new(Some(0), Position::new(8), 5, 13, 21, 34);
+        let interval =
+            Interval::from(Position::try_from(13).unwrap()..=Position::try_from(21).unwrap());
+
+        assert!(!intersects_index_record(&record, 0, interval));
+    }
+
+    #[test]
+    fn test_intersects_index_record_with_different_reference_sequence() {
+        let record = crai::Record::new(Some(1), Position::new(8), 5, 13, 21, 34);
+        let interval = Interval::from(Position::MIN..=Position::MAX);
+
+        assert!(!intersects_index_record(&record, 0, interval));
+    }
+
+    fn build_record(
+        reference_sequence_id: usize,
+        alignment_start: usize,
+        alignment_span: usize,
+    ) -> sam::alignment::RecordBuf {
+        let cigar: Cigar = [Op::new(Kind::Match, alignment_span)].into_iter().collect();
+
+        sam::alignment::RecordBuf::builder()
+            .set_reference_sequence_id(reference_sequence_id)
+            .set_alignment_start(Position::try_from(alignment_start).unwrap())
+            .set_cigar(cigar)
+            .build()
+    }
 }

--- a/noodles-cram/src/io/reader/container.rs
+++ b/noodles-cram/src/io/reader/container.rs
@@ -56,6 +56,30 @@ impl Container {
             }
         })
     }
+
+    /// Returns the slice at the given landmark.
+    pub(crate) fn slice(&self, landmark: u64) -> io::Result<Slice<'_>> {
+        let landmark =
+            usize::try_from(landmark).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        let i = self
+            .header
+            .landmarks
+            .iter()
+            .position(|&pos| pos == landmark)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid landmark"))?;
+
+        let end = self
+            .header
+            .landmarks
+            .get(i + 1)
+            .copied()
+            .unwrap_or(self.src.len());
+
+        let mut src = &self.src[landmark..end];
+
+        read_slice(&mut src)
+    }
 }
 
 pub fn read_container<R>(reader: &mut R, container: &mut Container) -> io::Result<usize>

--- a/noodles-cram/src/io/reader/query.rs
+++ b/noodles-cram/src/io/reader/query.rs
@@ -56,7 +56,7 @@ where
     fn read_next_container(&mut self) -> Option<io::Result<()>> {
         let index_record = self.index.next()?;
 
-        if index_record.reference_sequence_id() != Some(self.reference_sequence_id) {
+        if !intersects_index_record(index_record, self.reference_sequence_id, self.interval) {
             return Some(Ok(()));
         }
 
@@ -77,45 +77,39 @@ where
             Err(e) => return Some(Err(e)),
         };
 
-        let records = container
-            .slices()
-            .map(|result| {
-                let slice = result?;
+        let slice = match container.slice(index_record.landmark()) {
+            Ok(slice) => slice,
+            Err(e) => return Some(Err(e)),
+        };
 
-                let (core_data_src, external_data_srcs) = slice.decode_blocks()?;
+        let (core_data_src, external_data_srcs) = match slice.decode_blocks() {
+            Ok(blocks) => blocks,
+            Err(e) => return Some(Err(e)),
+        };
 
-                slice
-                    .records(
-                        self.reader.reference_sequence_repository.clone(),
-                        self.header,
-                        &compression_header,
-                        &core_data_src,
-                        &external_data_srcs,
-                    )
-                    .and_then(|records| {
-                        records
-                            .into_iter()
-                            .map(|record| {
-                                sam::alignment::RecordBuf::try_from_alignment_record(
-                                    self.header,
-                                    &record,
-                                )
-                            })
-                            .collect::<io::Result<Vec<_>>>()
+        let records = slice
+            .records(
+                self.reader.reference_sequence_repository.clone(),
+                self.header,
+                &compression_header,
+                &core_data_src,
+                &external_data_srcs,
+            )
+            .and_then(|records| {
+                records
+                    .into_iter()
+                    .map(|record| {
+                        sam::alignment::RecordBuf::try_from_alignment_record(self.header, &record)
                     })
-            })
-            .collect::<Result<Vec<_>, _>>();
+                    .collect::<io::Result<Vec<_>>>()
+            });
 
         let records = match records {
             Ok(records) => records,
             Err(e) => return Some(Err(e)),
         };
 
-        self.records = records
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .into_iter();
+        self.records = records.into_iter();
 
         Some(Ok(()))
     }
@@ -131,7 +125,7 @@ where
         loop {
             match self.records.next() {
                 Some(record) => {
-                    if intersects(&record, self.interval) {
+                    if intersects(&record, self.reference_sequence_id, self.interval) {
                         return Some(Ok(record));
                     }
                 }
@@ -145,12 +139,109 @@ where
     }
 }
 
-fn intersects(record: &sam::alignment::RecordBuf, region_interval: Interval) -> bool {
-    match (record.alignment_start(), record.alignment_end()) {
-        (Some(start), Some(end)) => {
+fn intersects(
+    record: &sam::alignment::RecordBuf,
+    reference_sequence_id: usize,
+    region_interval: Interval,
+) -> bool {
+    match (
+        record.reference_sequence_id(),
+        record.alignment_start(),
+        record.alignment_end(),
+    ) {
+        (Some(id), Some(start), Some(end)) if id == reference_sequence_id => {
             let alignment_interval = (start..=end).into();
             region_interval.intersects(alignment_interval)
         }
         _ => false,
+    }
+}
+
+fn intersects_index_record(
+    record: &crai::Record,
+    reference_sequence_id: usize,
+    region_interval: Interval,
+) -> bool {
+    if record.reference_sequence_id() != Some(reference_sequence_id) {
+        return false;
+    }
+
+    let Some(start) = record.alignment_start() else {
+        return false;
+    };
+
+    let Some(end) = start.checked_add(record.alignment_span().saturating_sub(1)) else {
+        return true;
+    };
+
+    region_interval.intersects((start..=end).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use noodles_core::Position;
+    use noodles_sam::alignment::{
+        record::cigar::{Op, op::Kind},
+        record_buf::Cigar,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_intersects() {
+        let record = build_record(0, 8, 5);
+        let interval =
+            Interval::from(Position::try_from(10).unwrap()..=Position::try_from(13).unwrap());
+
+        assert!(intersects(&record, 0, interval));
+    }
+
+    #[test]
+    fn test_intersects_with_different_reference_sequence() {
+        let record = build_record(1, 8, 5);
+        let interval =
+            Interval::from(Position::try_from(10).unwrap()..=Position::try_from(13).unwrap());
+
+        assert!(!intersects(&record, 0, interval));
+    }
+
+    #[test]
+    fn test_intersects_index_record() {
+        let record = crai::Record::new(Some(0), Position::new(8), 5, 13, 21, 34);
+        let interval =
+            Interval::from(Position::try_from(10).unwrap()..=Position::try_from(13).unwrap());
+
+        assert!(intersects_index_record(&record, 0, interval));
+    }
+
+    #[test]
+    fn test_intersects_index_record_with_nonoverlapping_interval() {
+        let record = crai::Record::new(Some(0), Position::new(8), 5, 13, 21, 34);
+        let interval =
+            Interval::from(Position::try_from(13).unwrap()..=Position::try_from(21).unwrap());
+
+        assert!(!intersects_index_record(&record, 0, interval));
+    }
+
+    #[test]
+    fn test_intersects_index_record_with_different_reference_sequence() {
+        let record = crai::Record::new(Some(1), Position::new(8), 5, 13, 21, 34);
+        let interval = Interval::from(Position::MIN..=Position::MAX);
+
+        assert!(!intersects_index_record(&record, 0, interval));
+    }
+
+    fn build_record(
+        reference_sequence_id: usize,
+        alignment_start: usize,
+        alignment_span: usize,
+    ) -> sam::alignment::RecordBuf {
+        let cigar: Cigar = [Op::new(Kind::Match, alignment_span)].into_iter().collect();
+
+        sam::alignment::RecordBuf::builder()
+            .set_reference_sequence_id(reference_sequence_id)
+            .set_alignment_start(Position::try_from(alignment_start).unwrap())
+            .set_cigar(cigar)
+            .build()
     }
 }


### PR DESCRIPTION
This updates CRAM indexed queries to use CRAI records as slice-level candidates before decoding.

Changes:

- Filter CRAI records by reference sequence and interval before seeking.
- Decode only the slice referenced by the CRAI landmark.
- Keep a final record-level reference and interval filter after decoding.
- Apply the same behavior to sync and async CRAM query readers.
- Add tests for CRAI interval filtering and cross-reference record filtering.

Why the record-level filter is still needed:

CRAI entries point to slices, but a CRAM slice can contain records from multiple reference sequences. After decoding the selected slice, the query still needs to filter individual records by reference sequence and interval. Without this, queries against multi-reference slices can return records from other references.

 Validation:

 - cargo test -p noodles-cram
 - cargo test -p noodles-cram --features async test_intersects
 - Compared cram_query output against samtools view 