### PR TITLE
cram/io/reader: Add record reader

### DIFF
--- a/noodles-cram/CHANGELOG.md
+++ b/noodles-cram/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+  * cram/io/reader: Add record reader (`Reader::read_record_buf`).
+
+    This reads the next alignment record into a reusable buffer, advancing
+    through containers and slices as needed. It mirrors
+    `bam::io::Reader::read_record_buf`, allowing records to be streamed without
+    holding a borrowing iterator alongside the reader.
+
+  * cram/io/indexed_reader: Add record reader
+    (`IndexedReader::read_record_buf`).
+
+### Changed
+
+  * cram/io/reader: `Reader::seek` now discards any records buffered by
+    `Reader::read_record_buf`, so reads after a seek start from the new
+    position.
+
 ## 0.94.0 - 2026-05-28
 
 ### Added

--- a/noodles-cram/src/io/indexed_reader.rs
+++ b/noodles-cram/src/io/indexed_reader.rs
@@ -74,6 +74,17 @@ where
         self.inner.read_container(container)
     }
 
+    /// Reads the next alignment record.
+    ///
+    /// This returns the number of records read, which is `0` if the end of the stream was reached.
+    pub fn read_record_buf(
+        &mut self,
+        header: &sam::Header,
+        record: &mut sam::alignment::RecordBuf,
+    ) -> io::Result<usize> {
+        self.inner.read_record_buf(header, record)
+    }
+
     /// Returns a iterator over records starting from the current stream position.
     pub fn records<'r, 'h: 'r>(&'r mut self, header: &'h sam::Header) -> Records<'r, 'h, R> {
         self.inner.records(header)

--- a/noodles-cram/src/io/reader.rs
+++ b/noodles-cram/src/io/reader.rs
@@ -8,14 +8,17 @@ pub(crate) mod num;
 mod query;
 mod records;
 
-use std::io::{self, Read, Seek, SeekFrom};
+use std::{
+    io::{self, Read, Seek, SeekFrom},
+    vec,
+};
 
 use noodles_core::Region;
 use noodles_fasta as fasta;
 use noodles_sam as sam;
 
 pub use self::{builder::Builder, container::Container, query::Query, records::Records};
-use self::{container::read_container, header::read_header};
+use self::{container::read_container, header::read_header, records::decode_container_records};
 use crate::{FileDefinition, crai};
 
 /// A CRAM reader.
@@ -43,6 +46,9 @@ use crate::{FileDefinition, crai};
 pub struct Reader<R> {
     inner: R,
     reference_sequence_repository: fasta::Repository,
+    container: Container,
+    records: vec::IntoIter<sam::alignment::RecordBuf>,
+    is_eof: bool,
 }
 
 impl<R> Reader<R> {
@@ -228,6 +234,67 @@ where
         read_container(&mut self.inner, container)
     }
 
+    /// Reads the next alignment record.
+    ///
+    /// The record is read into `record`, replacing its previous contents. This advances through
+    /// containers and slices as needed, decoding a whole container at a time and buffering its
+    /// records internally so that subsequent calls are served from the buffer.
+    ///
+    /// The stream is expected to be at the start of a container.
+    ///
+    /// This returns the number of records read, which is `0` if the end of the stream was reached.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use std::{fs::File, io};
+    /// use noodles_cram as cram;
+    /// use noodles_sam::alignment::RecordBuf;
+    ///
+    /// let mut reader = File::open("sample.cram").map(cram::io::Reader::new)?;
+    /// let header = reader.read_header()?;
+    ///
+    /// let mut record = RecordBuf::default();
+    ///
+    /// while reader.read_record_buf(&header, &mut record)? != 0 {
+    ///     // ...
+    /// }
+    /// # Ok::<_, io::Error>(())
+    /// ```
+    pub fn read_record_buf(
+        &mut self,
+        header: &sam::Header,
+        record: &mut sam::alignment::RecordBuf,
+    ) -> io::Result<usize> {
+        loop {
+            if let Some(r) = self.records.next() {
+                *record = r;
+                return Ok(1);
+            }
+
+            if !self.read_next_container_records(header)? {
+                return Ok(0);
+            }
+        }
+    }
+
+    fn read_next_container_records(&mut self, header: &sam::Header) -> io::Result<bool> {
+        if self.is_eof {
+            return Ok(false);
+        }
+
+        if read_container(&mut self.inner, &mut self.container)? == 0 {
+            self.is_eof = true;
+            return Ok(false);
+        }
+
+        self.records =
+            decode_container_records(&self.reference_sequence_repository, header, &self.container)?
+                .into_iter();
+
+        Ok(true)
+    }
+
     /// Returns a iterator over records starting from the current stream position.
     ///
     /// The stream is expected to be at the start of a container.
@@ -261,6 +328,9 @@ where
     ///
     /// Positions typically come from the associated CRAM index file.
     ///
+    /// This discards any records buffered by [`Self::read_record_buf`], as the stream position no
+    /// longer matches the buffer.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -271,7 +341,12 @@ where
     /// # Ok::<(), io::Error>(())
     /// ```
     pub fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        self.inner.seek(pos)
+        let position = self.inner.seek(pos)?;
+
+        self.records = Vec::new().into_iter();
+        self.is_eof = false;
+
+        Ok(position)
     }
 
     /// Returns the current position of the underlying reader.
@@ -371,7 +446,7 @@ where
             .map(|record| SeekFrom::Start(record.offset()))
             .unwrap_or(SeekFrom::End(0));
 
-        self.get_mut().seek(offset)?;
+        self.seek(offset)?;
 
         Ok(self.records(header).filter_map(|result| match result {
             Ok(record) => {
@@ -403,5 +478,150 @@ where
                 result.map(|record| Box::new(record) as Box<dyn sam::alignment::Record>)
             }),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::Cursor, num::NonZero};
+
+    use noodles_core::Position;
+    use noodles_sam::{
+        alignment::{
+            RecordBuf,
+            io::Write,
+            record::{
+                Flags,
+                cigar::{Op, op::Kind},
+            },
+            record_buf::Sequence,
+        },
+        header::record::value::{Map, map::ReferenceSequence},
+    };
+
+    use super::*;
+    use crate::io::writer;
+
+    const REFERENCE_SEQUENCE: &[u8] = b"TTCACCCA";
+
+    fn mapped_record(alignment_start: usize, bases: &[u8]) -> RecordBuf {
+        RecordBuf::builder()
+            .set_flags(Flags::empty())
+            .set_reference_sequence_id(0)
+            .set_alignment_start(Position::new(alignment_start).unwrap())
+            .set_cigar([Op::new(Kind::Match, bases.len())].into_iter().collect())
+            .set_sequence(Sequence::from(bases.to_vec()))
+            .set_quality_scores(vec![45; bases.len()].into_iter().collect())
+            .build()
+    }
+
+    fn write_fixture(
+        records: &[RecordBuf],
+    ) -> io::Result<(sam::Header, fasta::Repository, Vec<u8>)> {
+        let reference_sequences = vec![fasta::Record::new(
+            fasta::record::Definition::new("sq0", None),
+            fasta::record::Sequence::from(REFERENCE_SEQUENCE.to_vec()),
+        )];
+
+        let length = NonZero::try_from(REFERENCE_SEQUENCE.len())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+        let header = sam::Header::builder()
+            .add_reference_sequence("sq0", Map::<ReferenceSequence>::new(length))
+            .build();
+
+        let repository = fasta::Repository::new(reference_sequences);
+
+        let mut buf = Vec::new();
+        let mut writer = writer::Builder::default()
+            .set_reference_sequence_repository(repository.clone())
+            .build_from_writer(&mut buf);
+
+        writer.write_header(&header)?;
+
+        for record in records {
+            writer.write_alignment_record(&header, record)?;
+        }
+
+        writer.try_finish(&header)?;
+
+        Ok((header, repository, buf))
+    }
+
+    #[test]
+    fn test_read_record_buf() -> io::Result<()> {
+        let (header, repository, buf) = write_fixture(&[mapped_record(1, b"TTCA")])?;
+
+        let mut reader = Builder::default()
+            .set_reference_sequence_repository(repository)
+            .build_from_reader(&buf[..]);
+        reader.read_header()?;
+
+        let mut record = RecordBuf::default();
+
+        assert_eq!(reader.read_record_buf(&header, &mut record)?, 1);
+        assert_eq!(record.sequence(), &Sequence::from(b"TTCA"));
+        assert_eq!(record.alignment_start(), Position::new(1));
+
+        // Once the end-of-file container is reached, further reads return 0 idempotently rather
+        // than attempting to read past it.
+        assert_eq!(reader.read_record_buf(&header, &mut record)?, 0);
+        assert_eq!(reader.read_record_buf(&header, &mut record)?, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_record_buf_across_containers() -> io::Result<()> {
+        // The writer emits a container per 10240 records, so one more than that spans two
+        // containers and exercises advancing across the boundary.
+        const RECORD_COUNT: usize = 10240 + 1;
+
+        let records = vec![mapped_record(1, b"TTCA"); RECORD_COUNT];
+        let (header, repository, buf) = write_fixture(&records)?;
+
+        let mut reader = Builder::default()
+            .set_reference_sequence_repository(repository)
+            .build_from_reader(&buf[..]);
+        reader.read_header()?;
+
+        let mut record = RecordBuf::default();
+        let mut n = 0;
+
+        while reader.read_record_buf(&header, &mut record)? != 0 {
+            n += 1;
+        }
+
+        assert_eq!(n, RECORD_COUNT);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_record_buf_after_seek_discards_buffer() -> io::Result<()> {
+        let records = [mapped_record(1, b"TTCA"), mapped_record(2, b"TCAC")];
+        let (header, repository, buf) = write_fixture(&records)?;
+
+        let mut reader = Builder::default()
+            .set_reference_sequence_repository(repository)
+            .build_from_reader(Cursor::new(buf));
+        reader.read_header()?;
+
+        // Both records decode from a single container, so reading the first buffers the second
+        // inside the reader.
+        let container_position = reader.position()?;
+
+        let mut record = RecordBuf::default();
+        assert_eq!(reader.read_record_buf(&header, &mut record)?, 1);
+        assert_eq!(record.alignment_start(), Position::new(1));
+
+        // Seeking back to the container discards that buffered record, so the next read starts
+        // over from the first record instead of yielding the stale buffer.
+        reader.seek(SeekFrom::Start(container_position))?;
+
+        assert_eq!(reader.read_record_buf(&header, &mut record)?, 1);
+        assert_eq!(record.alignment_start(), Position::new(1));
+
+        Ok(())
     }
 }

--- a/noodles-cram/src/io/reader/builder.rs
+++ b/noodles-cram/src/io/reader/builder.rs
@@ -69,6 +69,9 @@ impl Builder {
         Reader {
             inner: reader,
             reference_sequence_repository: self.reference_sequence_repository,
+            container: Default::default(),
+            records: Vec::new().into_iter(),
+            is_eof: false,
         }
     }
 }

--- a/noodles-cram/src/io/reader/query.rs
+++ b/noodles-cram/src/io/reader/query.rs
@@ -6,7 +6,7 @@ use std::{
 use noodles_core::region::Interval;
 use noodles_sam as sam;
 
-use super::{Container, Reader};
+use super::{Container, Reader, records::decode_container_records};
 use crate::crai;
 
 /// An iterator over records that intersect a given region.
@@ -72,50 +72,16 @@ where
             Err(e) => return Some(Err(e)),
         };
 
-        let compression_header = match container.compression_header() {
-            Ok(compression_header) => compression_header,
-            Err(e) => return Some(Err(e)),
-        };
-
-        let records = container
-            .slices()
-            .map(|result| {
-                let slice = result?;
-
-                let (core_data_src, external_data_srcs) = slice.decode_blocks()?;
-
-                slice
-                    .records(
-                        self.reader.reference_sequence_repository.clone(),
-                        self.header,
-                        &compression_header,
-                        &core_data_src,
-                        &external_data_srcs,
-                    )
-                    .and_then(|records| {
-                        records
-                            .into_iter()
-                            .map(|record| {
-                                sam::alignment::RecordBuf::try_from_alignment_record(
-                                    self.header,
-                                    &record,
-                                )
-                            })
-                            .collect::<io::Result<Vec<_>>>()
-                    })
-            })
-            .collect::<Result<Vec<_>, _>>();
-
-        let records = match records {
+        let records = match decode_container_records(
+            &self.reader.reference_sequence_repository,
+            self.header,
+            &container,
+        ) {
             Ok(records) => records,
             Err(e) => return Some(Err(e)),
         };
 
-        self.records = records
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .into_iter();
+        self.records = records.into_iter();
 
         Some(Ok(()))
     }

--- a/noodles-cram/src/io/reader/records.rs
+++ b/noodles-cram/src/io/reader/records.rs
@@ -1,8 +1,6 @@
-use std::{
-    io::{self, Read},
-    vec,
-};
+use std::io::{self, Read};
 
+use noodles_fasta as fasta;
 use noodles_sam as sam;
 
 use super::{Container, Reader};
@@ -16,8 +14,6 @@ where
 {
     reader: &'r mut Reader<R>,
     header: &'h sam::Header,
-    container: Container,
-    records: vec::IntoIter<sam::alignment::RecordBuf>,
 }
 
 impl<'r, 'h: 'r, R> Records<'r, 'h, R>
@@ -25,56 +21,7 @@ where
     R: Read,
 {
     pub(crate) fn new(reader: &'r mut Reader<R>, header: &'h sam::Header) -> Self {
-        Self {
-            reader,
-            header,
-            container: Container::default(),
-            records: Vec::new().into_iter(),
-        }
-    }
-
-    fn read_container_records(&mut self) -> io::Result<bool> {
-        if self.reader.read_container(&mut self.container)? == 0 {
-            return Ok(true);
-        }
-
-        let compression_header = self.container.compression_header()?;
-
-        self.records = self
-            .container
-            .slices()
-            .map(|result| {
-                let slice = result?;
-
-                let (core_data_src, external_data_srcs) = slice.decode_blocks()?;
-
-                slice
-                    .records(
-                        self.reader.reference_sequence_repository.clone(),
-                        self.header,
-                        &compression_header,
-                        &core_data_src,
-                        &external_data_srcs,
-                    )
-                    .and_then(|records| {
-                        records
-                            .into_iter()
-                            .map(|record| {
-                                sam::alignment::RecordBuf::try_from_alignment_record(
-                                    self.header,
-                                    &record,
-                                )
-                            })
-                            .collect::<io::Result<Vec<_>>>()
-                    })
-            })
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .into_iter();
-
-        Ok(false)
+        Self { reader, header }
     }
 }
 
@@ -85,15 +32,49 @@ where
     type Item = io::Result<sam::alignment::RecordBuf>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match self.records.next() {
-                Some(r) => return Some(Ok(r)),
-                None => match self.read_container_records() {
-                    Ok(true) => return None,
-                    Ok(false) => {}
-                    Err(e) => return Some(Err(e)),
-                },
-            }
+        let mut record = sam::alignment::RecordBuf::default();
+
+        match self.reader.read_record_buf(self.header, &mut record) {
+            Ok(0) => None,
+            Ok(_) => Some(Ok(record)),
+            Err(e) => Some(Err(e)),
         }
     }
+}
+
+/// Decodes all records of a container into owned alignment records.
+pub(super) fn decode_container_records(
+    reference_sequence_repository: &fasta::Repository,
+    header: &sam::Header,
+    container: &Container,
+) -> io::Result<Vec<sam::alignment::RecordBuf>> {
+    let compression_header = container.compression_header()?;
+
+    let records = container
+        .slices()
+        .map(|result| {
+            let slice = result?;
+
+            let (core_data_src, external_data_srcs) = slice.decode_blocks()?;
+
+            slice
+                .records(
+                    reference_sequence_repository.clone(),
+                    header,
+                    &compression_header,
+                    &core_data_src,
+                    &external_data_srcs,
+                )
+                .and_then(|records| {
+                    records
+                        .into_iter()
+                        .map(|record| {
+                            sam::alignment::RecordBuf::try_from_alignment_record(header, &record)
+                        })
+                        .collect::<io::Result<Vec<_>>>()
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(records.into_iter().flatten().collect())
 }


### PR DESCRIPTION
Fixes #398

Heads up that this PR is primarily LLM-driven. I've done my best to make it clean as possible and the logic / diff looks sane to me, but I'm not experienced in Rust or this library so I totally defer to everyone here 😅 I hope it's helpful!

### What

Adds a stateful, borrow-free per-record read method to the CRAM reader, mirroring `bam::io::Reader::read_record_buf` and `sam::io::Reader::read_record_buf`:

```rust
impl<R: Read> cram::io::Reader<R> {
    /// Reads the next alignment record, advancing through containers/slices as needed.
    /// Returns the number of records read, which is `0` at end of stream.
    pub fn read_record_buf(
        &mut self,
        header: &sam::Header,
        record: &mut RecordBuf,
    ) -> io::Result<usize>;
}
```

The same method is added to `IndexedReader`, delegating to the inner reader. This lets callers stream CRAM with O(1) reader state, without holding a borrowing iterator (`records()` / `query()`) alongside the reader. See #398 for the full motivation.

<details><summary><h3>More details</h3></summary>

### How

The per-container decode state (a `Container` buffer plus a `vec::IntoIter<RecordBuf>` for the active container) moves from `reader::Records` into `Reader`. `read_record_buf` serves records from that buffer, decoding the next container only when the buffer drains.

The whole-container decode loop is factored into a single `decode_container_records` helper, shared by three call sites:

- `Reader::read_record_buf` — the new primitive.
- `Records` — now a thin iterator over `read_record_buf`.
- `Query::read_next_container` — switched onto the shared helper, removing a near-identical inlined copy of the decode loop.

Decode granularity is unchanged: a CRAM slice is still decoded as a whole column-major batch (required for in-batch mate resolution, distinct from the per-record decode discussed in #126); records are buffered in the reader and handed out one at a time.

Two correctness details follow from buffering records in the reader:

- **Idempotent at end of stream.** Once the EOF container is reached, `read_record_buf` returns `0` on every subsequent call rather than reading past it, matching `bam`/`sam`.
- **Seek discards the buffer.** Because the buffer outlives a single `records()` call, `Reader::seek` clears it so a read after a seek starts from the new position instead of yielding stale buffered records. `query_unmapped`, which seeks before streaming, goes through `Reader::seek` for this reason.

### Out of scope

A stateful cursor for the indexed `query`/`query_unmapped` case (a `seek` + `read_record_buf` pairing) is a natural follow-up but a larger design question, as it would add query-specific state to the reader. `query()`/`query_unmapped()` are unchanged here and now share the same decode helper.

### Alternatives considered

- **Expose the per-container decode helpers** (`Container::compression_header`/`slices`, `Slice::decode_blocks`/`records`, a public repository accessor). This also unblocks hand-rolling, but exposes a much larger, lower-level surface and asks every caller to re-implement the container/slice decode loop. The `read_record_buf` approach is smaller and matches existing precedent.
- **Keep using a self-referential wrapper downstream.** Works today, but it's a workaround for a missing primitive, and every CRAM consumer has to carry it.

### Testing

- `cargo test -p noodles-cram` — 225 unit tests + 77 doctests pass.
- `cargo clippy -p noodles-cram --all-targets` — clean.
- `cargo fmt -p noodles-cram -- --check` — clean.
- Added write -> read roundtrip unit tests for `read_record_buf` covering a single record (plus idempotent end-of-stream), spanning more than one container, and discarding the buffer on seek. These are the first in-crate execution tests of the CRAM read path; previously only `no_run` doctests existed.
- Added a CHANGELOG entry.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
