### PR TITLE
bgzf/io/multithreaded_reader: decouple (somewhat) read-ahead depth from worker count

### DIFF
--- a/noodles-bgzf/src/io/multithreaded_reader.rs
+++ b/noodles-bgzf/src/io/multithreaded_reader.rs
@@ -174,10 +174,16 @@ where
 
         let worker_count = rayon::current_num_threads();
 
-        let (read_tx, read_rx) = crossbeam_channel::bounded(worker_count);
-        let (recycle_tx, recycle_rx) = crossbeam_channel::bounded(worker_count);
+        // Sizing the channels and buffer pool to `worker_count` alone can stall the
+        // pipeline when the pool is small: a single worker leaves one buffer in flight,
+        // so the reader can't run ahead of the consumer. Keep a small floor.
+        const MIN_BUFFERS: usize = 8;
+        let capacity = worker_count.max(MIN_BUFFERS);
 
-        for _ in 0..worker_count {
+        let (read_tx, read_rx) = crossbeam_channel::bounded(capacity);
+        let (recycle_tx, recycle_rx) = crossbeam_channel::bounded(capacity);
+
+        for _ in 0..capacity {
             recycle_tx.send(Buffer::default()).unwrap();
         }
 


### PR DESCRIPTION
@zaeleus I ran into this with the existing (released) non-rayon based implementation, and stumbled into your rayon based changes when I came to make a PR.  I've benchmarked both the older threading and the rayon-based, when doing multi-threaded decompression of a single BAM.

Both implementation actually regress performance for me at threads=1 (i.e. adding a single dedicated thread for decompression).  The root cause seems to be that crossbeam's bounded length=1 channel doesn't allow the actual decompression thread to get ahead.  When running in Riker where the main thread was doing about equal work to bgzf inflate, I would see runtime go _up_ when adding the first decompression thread, then dip significantly when adding a second thread.  I patched and tested locally with just upping the channel size to a small number (2, 4, 8) and that was all that was needed to have the +1 threads provide the expected performance boost.  It does seem like there's some marginal benefit to having ~a few extra slots at low thread counts, and since the memory usage is small (~64kb per slot) it seems cheap.