### PR TITLE
vcf/header/parser: Honor header definitions of reserved keys

### DIFF
--- a/noodles-vcf/src/header/parser/record/value.rs
+++ b/noodles-vcf/src/header/parser/record/value.rs
@@ -10,6 +10,7 @@ use crate::header::{
 };
 
 /// An error returned when a VCF header record value fails to parse.
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ParseError {
     InvalidFileFormat(string::file_format::ParseError),
@@ -20,28 +21,6 @@ pub enum ParseError {
     InvalidContig(map::contig::ParseError),
     InvalidOtherString(key::Other, string::ParseError),
     InvalidOtherMap(key::Other, map::other::ParseError),
-    FormatDefinitionMismatch {
-        id: String,
-        actual: (
-            crate::header::record::value::map::format::Number,
-            crate::header::record::value::map::format::Type,
-        ),
-        expected: (
-            crate::header::record::value::map::format::Number,
-            crate::header::record::value::map::format::Type,
-        ),
-    },
-    InfoDefinitionMismatch {
-        id: String,
-        actual: (
-            crate::header::record::value::map::info::Number,
-            crate::header::record::value::map::info::Type,
-        ),
-        expected: (
-            crate::header::record::value::map::info::Number,
-            crate::header::record::value::map::info::Type,
-        ),
-    },
 }
 
 impl error::Error for ParseError {
@@ -55,7 +34,6 @@ impl error::Error for ParseError {
             Self::InvalidContig(e) => Some(e),
             Self::InvalidOtherString(_, e) => Some(e),
             Self::InvalidOtherMap(_, e) => Some(e),
-            _ => None,
         }
     }
 }
@@ -123,42 +101,6 @@ impl fmt::Display for ParseError {
 
                 Ok(())
             }
-            Self::FormatDefinitionMismatch {
-                id,
-                actual,
-                expected,
-            } => {
-                let (actual_number, actual_type) = actual;
-                let (expected_number, expected_type) = expected;
-
-                write!(
-                    f,
-                    "{} definition mismatch: ID={id}: expected Number={:?},Type={}, got Number={:?},Type={}",
-                    key::FORMAT,
-                    expected_number,
-                    expected_type,
-                    actual_number,
-                    actual_type,
-                )
-            }
-            Self::InfoDefinitionMismatch {
-                id,
-                actual,
-                expected,
-            } => {
-                let (actual_number, actual_type) = actual;
-                let (expected_number, expected_type) = expected;
-
-                write!(
-                    f,
-                    "{} definition mismatch: ID={id}: expected Number={:?},Type={}, got Number={:?},Type={}",
-                    key::INFO,
-                    expected_number,
-                    expected_type,
-                    actual_number,
-                    actual_type,
-                )
-            }
         }
     }
 }
@@ -175,20 +117,15 @@ pub(super) fn parse_value(
         key::FILE_FORMAT => string::parse_file_format(src)
             .map(Record::FileFormat)
             .map_err(ParseError::InvalidFileFormat),
-        key::INFO => {
-            let (id, map) = map::parse_info(src, file_format).map_err(ParseError::InvalidInfo)?;
-            validate_info_definition(file_format, &id, map.number(), map.ty())?;
-            Ok(Record::Info(id, map))
-        }
+        key::INFO => map::parse_info(src, file_format)
+            .map(|(id, map)| Record::Info(id, map))
+            .map_err(ParseError::InvalidInfo),
         key::FILTER => map::parse_filter(src)
             .map(|(id, map)| Record::Filter(id, map))
             .map_err(ParseError::InvalidFilter),
-        key::FORMAT => {
-            let (id, map) =
-                map::parse_format(src, file_format).map_err(ParseError::InvalidFormat)?;
-            validate_format_definition(file_format, &id, map.number(), map.ty())?;
-            Ok(Record::Format(id, map))
-        }
+        key::FORMAT => map::parse_format(src, file_format)
+            .map(|(id, map)| Record::Format(id, map))
+            .map_err(ParseError::InvalidFormat),
         key::ALTERNATIVE_ALLELE => map::parse_alternative_allele(src)
             .map(|(id, map)| Record::AlternativeAllele(id, map))
             .map_err(ParseError::InvalidAlternativeAllele),
@@ -219,44 +156,59 @@ pub(super) fn parse_value(
     }
 }
 
-fn validate_format_definition(
-    file_format: FileFormat,
-    id: &str,
-    actual_number: crate::header::record::value::map::format::Number,
-    actual_type: crate::header::record::value::map::format::Type,
-) -> Result<(), ParseError> {
-    use crate::header::record::value::map::format::definition::definition;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    if let Some((expected_number, expected_type, _)) = definition(file_format, id)
-        && (actual_number != expected_number || actual_type != expected_type)
-    {
-        return Err(ParseError::FormatDefinitionMismatch {
-            id: id.into(),
-            actual: (actual_number, actual_type),
-            expected: (expected_number, expected_type),
-        });
+    #[test]
+    fn test_parse_value_with_redefined_reserved_format_key() {
+        use crate::header::record::value::map::format::{Number, Type};
+
+        // A header may loosen a reserved field's `Number` (e.g. `DP` from the reserved
+        // `Number=1` to `Number=.`). Such a definition is valid VCF and must be honored
+        // rather than rejected against the version-reserved default.
+        let mut src = &b"<ID=DP,Number=.,Type=Integer,Description=\"d\">"[..];
+        let record = parse_value(&mut src, FileFormat::new(4, 4), key::FORMAT).unwrap();
+
+        match record {
+            Record::Format(id, map) => {
+                assert_eq!(id, "DP");
+                assert_eq!(map.number(), Number::Unknown);
+                assert_eq!(map.ty(), Type::Integer);
+            }
+            _ => panic!("expected a FORMAT record"),
+        }
+
+        // `AD` is reserved as `Number=R`; a header declaring `Number=.` must be honored.
+        let mut src = &b"<ID=AD,Number=.,Type=Integer,Description=\"a\">"[..];
+        let record = parse_value(&mut src, FileFormat::new(4, 4), key::FORMAT).unwrap();
+
+        match record {
+            Record::Format(id, map) => {
+                assert_eq!(id, "AD");
+                assert_eq!(map.number(), Number::Unknown);
+                assert_eq!(map.ty(), Type::Integer);
+            }
+            _ => panic!("expected a FORMAT record"),
+        }
     }
 
-    Ok(())
-}
+    #[test]
+    fn test_parse_value_with_redefined_reserved_info_key() {
+        use crate::header::record::value::map::info::{Number, Type};
 
-fn validate_info_definition(
-    file_format: FileFormat,
-    id: &str,
-    actual_number: crate::header::record::value::map::info::Number,
-    actual_type: crate::header::record::value::map::info::Type,
-) -> Result<(), ParseError> {
-    use crate::header::record::value::map::info::definition::definition;
+        // `DP` is reserved in INFO as `Number=1`; a header declaring `Number=.` must be
+        // honored rather than rejected.
+        let mut src = &b"<ID=DP,Number=.,Type=Integer,Description=\"d\">"[..];
+        let record = parse_value(&mut src, FileFormat::new(4, 4), key::INFO).unwrap();
 
-    if let Some((expected_number, expected_type, _)) = definition(file_format, id)
-        && (actual_number != expected_number || actual_type != expected_type)
-    {
-        return Err(ParseError::InfoDefinitionMismatch {
-            id: id.into(),
-            actual: (actual_number, actual_type),
-            expected: (expected_number, expected_type),
-        });
+        match record {
+            Record::Info(id, map) => {
+                assert_eq!(id, "DP");
+                assert_eq!(map.number(), Number::Unknown);
+                assert_eq!(map.ty(), Type::Integer);
+            }
+            _ => panic!("expected an INFO record"),
+        }
     }
-
-    Ok(())
 }

--- a/noodles-vcf/src/io/reader.rs
+++ b/noodles-vcf/src/io/reader.rs
@@ -472,6 +472,35 @@ sq0\t1\t.\tA\t.\t.\tPASS\t.
     }
 
     #[test]
+    fn test_read_header_with_redefined_reserved_key() -> io::Result<()> {
+        // A header may loosen a reserved field's `Number` (e.g. declare the reserved
+        // `DP`/`AD` FORMAT keys with `Number=.`). This is valid VCF and accepted by
+        // htslib, so reading the header and record must succeed even when the declared
+        // `fileformat` is 4.3 or later.
+        static DATA: &[u8] = b"\
+##fileformat=VCFv4.4
+##contig=<ID=chr1,length=248956422>
+##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">
+##FORMAT=<ID=DP,Number=.,Type=Integer,Description=\"d\">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description=\"a\">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1
+chr1\t53210776\t.\tG\tA\t50\tPASS\t.\tGT:DP:AD\t1/1:512:5,7
+";
+
+        let mut reader = Reader::new(DATA);
+        let header = reader.read_header()?;
+
+        let mut record = RecordBuf::default();
+        let bytes_read = reader.read_record_buf(&header, &mut record)?;
+        assert!(bytes_read > 0);
+
+        let bytes_read = reader.read_record_buf(&header, &mut record)?;
+        assert_eq!(bytes_read, 0);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_read_line() -> io::Result<()> {
         let mut buf = String::new();
 


### PR DESCRIPTION
## Problem

`noodles-vcf`'s header record parser rejects any `##INFO`/`##FORMAT` definition of a *reserved* key whose `Number` (or `Type`) differs from the version-reserved default, but only for files declaring `##fileformat=VCFv4.3` or later. The same file declared as `VCFv4.2` parses fine, and htslib/bcftools accept it regardless.

Minimal repro (fails on 4.3/4.4/4.5, OK on 4.2):

```
##fileformat=VCFv4.4
##contig=<ID=chr1,length=248956422>
##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
##FORMAT=<ID=DP,Number=.,Type=Integer,Description="d">
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1
chr1	53210776	.	G	A	50	PASS	.	GT:DP	1/1:512
```

`read_header()` returns an `io::Error` ("invalid record") because `DP` is reserved as `Number=1`. `AD` declared as `Number=.` (reserved `Number=R`) fails the same way. These headers are legal VCF: a file may loosen a reserved field's `Number`.

## Fix

The header parser's `validate_format_definition`/`validate_info_definition` compared the header's declared `(Number, Type)` against the version-reserved default and errored on any difference. This is both spec-incorrect and inconsistent with the rest of the crate: both the `record_buf` and lazy `record` value readers already prefer the header's declared `(Number, Type)` over the reserved definition when parsing values, so the header was authoritative everywhere except this one gatekeeping check. This change drops that validation so an explicitly declared reserved key is honored. Keys the header does not declare are unaffected and still fall back to the version-reserved definition.

## Tests

Added regression tests: `parse_value` on redefined reserved FORMAT (`DP`, `AD` with `Number=.`) and INFO (`DP` with `Number=.`) keys under VCFv4.4, plus an end-to-end `Reader` test reading the minimal repro VCF. `cargo test`, `cargo fmt --check`, and `cargo clippy --all-features -- --deny warnings` all pass.
