### PR TITLE
Compact binning indices (BAI/CSI/TBI) to match htslib/samtools

### DIFF
--- a/noodles-csi/CHANGELOG.md
+++ b/noodles-csi/CHANGELOG.md
@@ -15,6 +15,14 @@
     reduces the size of the index for dense data (e.g. a human WGS BAI shrinks
     by roughly an order of magnitude). Query results are unchanged.
 
+  * csi/binning_index/indexer: Merge chunks of consecutive records in the same
+    bin.
+
+    A run of consecutive records assigned to the same bin is now stored as a
+    single chunk spanning any BGZF block boundaries within the run, rather than
+    one chunk per block, matching htslib's `hts_idx_push`. This reduces the
+    number of chunks per bin. Query results are unchanged.
+
 ## 0.57.0 - 2026-07-10
 
 ### Changed

--- a/noodles-csi/CHANGELOG.md
+++ b/noodles-csi/CHANGELOG.md
@@ -6,6 +6,15 @@
 
   * csi: Update to bit-vec 0.10.1.
 
+  * csi/binning_index/index/reference_sequence: Compact bins when building an
+    index.
+
+    After the index is built, a bin whose records span less than 64 KiB of
+    compressed data is folded into its parent bin, and chunks sharing a BGZF
+    block are merged, matching htslib's `compress_binning`. This substantially
+    reduces the size of the index for dense data (e.g. a human WGS BAI shrinks
+    by roughly an order of magnitude). Query results are unchanged.
+
 ## 0.57.0 - 2026-07-10
 
 ### Changed

--- a/noodles-csi/src/binning_index/index/reference_sequence.rs
+++ b/noodles-csi/src/binning_index/index/reference_sequence.rs
@@ -209,6 +209,16 @@ where
         self.index.last_first_start_position()
     }
 
+    // Adds or merges a chunk into the given bin, creating the bin if necessary.
+    pub(crate) fn add_chunk(&mut self, bin_id: usize, chunk: Chunk) {
+        self.bins
+            .entry(bin_id)
+            .or_insert(Bin::new(Vec::new()))
+            .add_chunk(chunk);
+    }
+
+    // Updates the linear index and metadata for a record. The chunk is the record's own, even when
+    // the bin stores a wider run chunk (see `Indexer::add_record`).
     pub(crate) fn update(
         &mut self,
         min_shift: u8,
@@ -218,10 +228,6 @@ where
         is_mapped: bool,
         chunk: Chunk,
     ) {
-        let id = reg2bin(start, end, min_shift, depth);
-        let bins = self.bins.entry(id).or_insert(Bin::new(Vec::new()));
-        bins.add_chunk(chunk);
-
         self.index.update(min_shift, depth, start, end, chunk);
 
         let metadata = self.metadata.get_or_insert(Metadata::new(
@@ -307,7 +313,7 @@ pub(crate) fn parent_id(id: usize) -> Option<usize> {
 }
 
 // `CSIv1.pdf` (2020-07-21)
-fn reg2bin(start: Position, end: Position, min_shift: u8, depth: u8) -> usize {
+pub(crate) fn reg2bin(start: Position, end: Position, min_shift: u8, depth: u8) -> usize {
     // [beg, end), 0-based
     let beg = usize::from(start) - 1;
     let end = usize::from(end);

--- a/noodles-csi/src/binning_index/index/reference_sequence.rs
+++ b/noodles-csi/src/binning_index/index/reference_sequence.rs
@@ -17,6 +17,11 @@ use self::bin::Chunk;
 use super::resolve_interval;
 use crate::binning_index;
 
+// A bin is kept only if its records span at least this many bytes of compressed data; a bin
+// covering less is folded into its parent during compaction. Same value as htslib's
+// HTS_MIN_MARKER_DIST (`compress_binning`, hts.c).
+const MIN_COMPRESSED_SPAN: u64 = 1 << 16;
+
 /// A binning index reference sequence.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReferenceSequence<I> {
@@ -228,6 +233,61 @@ where
 
         metadata.update(is_mapped, chunk);
     }
+
+    // Folds bins that span little compressed data into their parents and merges chunks that share a
+    // BGZF block, matching htslib's `compress_binning`. This significantly reduces the size of the
+    // index without changing query results.
+    pub(crate) fn compact(&mut self) {
+        // Snapshot the insertion order so serialization stays deterministic after the folding
+        // below (bins are an ordered map for this reason).
+        let order: Vec<usize> = self.bins.keys().copied().collect();
+
+        // First pass: fold a bin into its parent when its records span less than
+        // `MIN_COMPRESSED_SPAN` bytes of compressed data. Bins are visited deepest first
+        // (descending ID) so that a bin has received all of its descendants' folded chunks before
+        // its own span is tested, and so a parent is never removed before its children are
+        // considered.
+        let mut ids = order.clone();
+        ids.sort_unstable();
+
+        for &id in ids.iter().rev() {
+            let Some(pid) = parent_id(id) else { continue };
+
+            let Some(bin) = self.bins.get_mut(&id) else {
+                continue;
+            };
+
+            bin.sort_chunks();
+
+            if bin.compressed_span() >= MIN_COMPRESSED_SPAN {
+                continue;
+            }
+
+            if !self.bins.contains_key(&pid) {
+                continue;
+            }
+
+            if let Some(bin) = self.bins.swap_remove(&id)
+                && let Some(parent) = self.bins.get_mut(&pid)
+            {
+                parent.extend_chunks(bin.into_chunks());
+            }
+        }
+
+        // Second pass: restore the original insertion order and, within each surviving bin, sort by
+        // start and merge chunks that share a BGZF block.
+        let mut compacted = IndexMap::with_capacity(self.bins.len());
+
+        for id in order {
+            if let Some(mut bin) = self.bins.swap_remove(&id) {
+                bin.sort_chunks();
+                bin.merge_chunks_in_same_block();
+                compacted.insert(id, bin);
+            }
+        }
+
+        self.bins = compacted;
+    }
 }
 
 impl<I> binning_index::ReferenceSequence for ReferenceSequence<I>
@@ -298,10 +358,16 @@ fn reg2bins(start: Position, end: Position, min_shift: u8, depth: u8, bins: &mut
 
 #[cfg(test)]
 mod tests {
+    use super::index::LinearIndex;
     use super::*;
 
     const MIN_SHIFT: u8 = 14;
     const DEPTH: u8 = 5;
+
+    // Builds a virtual position from a compressed (block) offset and an uncompressed offset.
+    fn vp(compressed: u64, uncompressed: u16) -> bgzf::VirtualPosition {
+        bgzf::VirtualPosition::try_from((compressed, uncompressed)).unwrap()
+    }
 
     #[cfg(not(target_pointer_width = "16"))]
     #[test]
@@ -388,5 +454,91 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_compact_folds_bin_into_parent() {
+        // Bin 4681 is a child of bin 585 (parent_id(4681) == 585).
+        let bins = [
+            (585, Bin::new(vec![Chunk::new(vp(1, 0), vp(1, 100))])),
+            (4681, Bin::new(vec![Chunk::new(vp(1, 100), vp(1, 200))])),
+        ]
+        .into_iter()
+        .collect();
+        let mut reference_sequence: ReferenceSequence<LinearIndex> =
+            ReferenceSequence::new(bins, Vec::new(), None);
+
+        reference_sequence.compact();
+
+        assert_eq!(reference_sequence.bins().len(), 1);
+        assert_eq!(
+            reference_sequence.bins()[&585].chunks(),
+            [Chunk::new(vp(1, 0), vp(1, 200))]
+        );
+    }
+
+    #[test]
+    fn test_compact_keeps_bin_without_parent() {
+        let bins = [(4681, Bin::new(vec![Chunk::new(vp(1, 0), vp(1, 100))]))]
+            .into_iter()
+            .collect();
+        let mut reference_sequence: ReferenceSequence<LinearIndex> =
+            ReferenceSequence::new(bins, Vec::new(), None);
+
+        reference_sequence.compact();
+
+        assert!(reference_sequence.bins().contains_key(&4681));
+    }
+
+    #[test]
+    fn test_compact_keeps_bin_with_large_span() {
+        let bins = [
+            (585, Bin::new(vec![Chunk::new(vp(0, 0), vp(0, 10))])),
+            (4681, Bin::new(vec![Chunk::new(vp(0, 0), vp(1 << 16, 0))])),
+        ]
+        .into_iter()
+        .collect();
+        let mut reference_sequence: ReferenceSequence<LinearIndex> =
+            ReferenceSequence::new(bins, Vec::new(), None);
+
+        reference_sequence.compact();
+
+        assert!(reference_sequence.bins().contains_key(&585));
+        assert!(reference_sequence.bins().contains_key(&4681));
+    }
+
+    #[test]
+    fn test_compact_does_not_fold_root() {
+        let bins = [(0, Bin::new(vec![Chunk::new(vp(0, 0), vp(0, 100))]))]
+            .into_iter()
+            .collect();
+        let mut reference_sequence: ReferenceSequence<LinearIndex> =
+            ReferenceSequence::new(bins, Vec::new(), None);
+
+        reference_sequence.compact();
+
+        assert!(reference_sequence.bins().contains_key(&0));
+    }
+
+    #[test]
+    fn test_compact_cascades() {
+        // Bin 4681 -> 585 -> 73 (each is the parent of the next); bin 9 (73's parent) is absent.
+        let bins = [
+            (73, Bin::new(vec![Chunk::new(vp(1, 0), vp(1, 10))])),
+            (585, Bin::new(vec![Chunk::new(vp(1, 10), vp(1, 20))])),
+            (4681, Bin::new(vec![Chunk::new(vp(1, 20), vp(1, 30))])),
+        ]
+        .into_iter()
+        .collect();
+        let mut reference_sequence: ReferenceSequence<LinearIndex> =
+            ReferenceSequence::new(bins, Vec::new(), None);
+
+        reference_sequence.compact();
+
+        assert_eq!(reference_sequence.bins().len(), 1);
+        assert_eq!(
+            reference_sequence.bins()[&73].chunks(),
+            [Chunk::new(vp(1, 0), vp(1, 30))]
+        );
     }
 }

--- a/noodles-csi/src/binning_index/index/reference_sequence/bin.rs
+++ b/noodles-csi/src/binning_index/index/reference_sequence/bin.rs
@@ -74,6 +74,53 @@ impl Bin {
 
         self.chunks.push(chunk);
     }
+
+    // Sorts the bin's chunks by their start position.
+    pub(crate) fn sort_chunks(&mut self) {
+        self.chunks.sort_unstable_by_key(|chunk| chunk.start());
+    }
+
+    // Returns the span of the bin's chunks in compressed (BGZF block) offset units, i.e., the
+    // distance between the first chunk's start block and the last chunk's end block. Assumes the
+    // chunks are sorted by start position.
+    pub(crate) fn compressed_span(&self) -> u64 {
+        match (self.chunks.first(), self.chunks.last()) {
+            (Some(first), Some(last)) => last.end().compressed() - first.start().compressed(),
+            _ => 0,
+        }
+    }
+
+    // Consumes the bin, returning its chunks.
+    pub(crate) fn into_chunks(self) -> Vec<Chunk> {
+        self.chunks
+    }
+
+    // Appends chunks to the bin.
+    pub(crate) fn extend_chunks(&mut self, chunks: Vec<Chunk>) {
+        self.chunks.extend(chunks);
+    }
+
+    // Merges chunks that share a BGZF block into single chunks. Assumes the chunks are sorted by
+    // start position. Matches the second pass of htslib's `compress_binning`.
+    pub(crate) fn merge_chunks_in_same_block(&mut self) {
+        if self.chunks.len() < 2 {
+            return;
+        }
+
+        let mut m = 0;
+
+        for l in 1..self.chunks.len() {
+            if self.chunks[m].end().compressed() >= self.chunks[l].start().compressed() {
+                let end = self.chunks[m].end().max(self.chunks[l].end());
+                self.chunks[m] = Chunk::new(self.chunks[m].start(), end);
+            } else {
+                m += 1;
+                self.chunks[m] = self.chunks[l];
+            }
+        }
+
+        self.chunks.truncate(m + 1);
+    }
 }
 
 // `CSIv1.pdf` (2020-07-21)
@@ -134,6 +181,78 @@ mod tests {
                     bgzf::VirtualPosition::from(34),
                     bgzf::VirtualPosition::from(55)
                 )
+            ]
+        );
+    }
+
+    // Builds a virtual position from a compressed (block) offset and an uncompressed offset.
+    fn vp(compressed: u64, uncompressed: u16) -> bgzf::VirtualPosition {
+        bgzf::VirtualPosition::try_from((compressed, uncompressed)).unwrap()
+    }
+
+    #[test]
+    fn test_sort_chunks() {
+        let mut bin = Bin::new(vec![
+            Chunk::new(vp(21, 0), vp(34, 0)),
+            Chunk::new(vp(5, 0), vp(13, 0)),
+            Chunk::new(vp(8, 0), vp(21, 0)),
+        ]);
+
+        bin.sort_chunks();
+
+        assert_eq!(
+            bin.chunks,
+            [
+                Chunk::new(vp(5, 0), vp(13, 0)),
+                Chunk::new(vp(8, 0), vp(21, 0)),
+                Chunk::new(vp(21, 0), vp(34, 0)),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_compressed_span() {
+        // last chunk's end block (7) - first chunk's start block (2)
+        let bin = Bin::new(vec![
+            Chunk::new(vp(2, 0), vp(2, 500)),
+            Chunk::new(vp(3, 0), vp(7, 100)),
+        ]);
+        assert_eq!(bin.compressed_span(), 5);
+
+        // a single chunk contained in one block
+        let bin = Bin::new(vec![Chunk::new(vp(4, 10), vp(4, 900))]);
+        assert_eq!(bin.compressed_span(), 0);
+    }
+
+    #[test]
+    fn test_merge_chunks_in_same_block() {
+        // two chunks within the same block are merged
+        let mut bin = Bin::new(vec![
+            Chunk::new(vp(0, 0), vp(0, 50)),
+            Chunk::new(vp(0, 50), vp(0, 100)),
+        ]);
+        bin.merge_chunks_in_same_block();
+        assert_eq!(bin.chunks, [Chunk::new(vp(0, 0), vp(0, 100))]);
+
+        // chunks sharing a block across a boundary are merged, taking the max end
+        let mut bin = Bin::new(vec![
+            Chunk::new(vp(0, 0), vp(1, 10)),
+            Chunk::new(vp(1, 20), vp(1, 30)),
+        ]);
+        bin.merge_chunks_in_same_block();
+        assert_eq!(bin.chunks, [Chunk::new(vp(0, 0), vp(1, 30))]);
+
+        // chunks in different blocks are kept separate
+        let mut bin = Bin::new(vec![
+            Chunk::new(vp(0, 0), vp(0, 50)),
+            Chunk::new(vp(1, 0), vp(1, 50)),
+        ]);
+        bin.merge_chunks_in_same_block();
+        assert_eq!(
+            bin.chunks,
+            [
+                Chunk::new(vp(0, 0), vp(0, 50)),
+                Chunk::new(vp(1, 0), vp(1, 50))
             ]
         );
     }

--- a/noodles-csi/src/binning_index/indexer.rs
+++ b/noodles-csi/src/binning_index/indexer.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use indexmap::IndexMap;
+use noodles_bgzf as bgzf;
 use noodles_core::Position;
 
 use super::index::{
@@ -16,6 +17,16 @@ pub struct Indexer<I> {
     header: Option<Header>,
     reference_sequences: Vec<ReferenceSequence<I>>,
     unplaced_unmapped_record_count: u64,
+    run: Option<Run>,
+}
+
+// Tracks a run of consecutive records assigned to the same bin so their chunks can be merged into a
+// single chunk spanning any BGZF block boundaries within the run, matching htslib's `hts_idx_push`.
+#[derive(Clone, Copy, Debug)]
+struct Run {
+    reference_sequence_id: usize,
+    bin_id: usize,
+    start: bgzf::VirtualPosition,
 }
 
 impl<I> Indexer<I>
@@ -37,6 +48,7 @@ where
             header: None,
             reference_sequences: Vec::new(),
             unplaced_unmapped_record_count: 0,
+            run: None,
         }
     }
 
@@ -92,6 +104,7 @@ where
         use std::cmp::Ordering;
 
         let Some((reference_sequence_id, start, end, is_mapped)) = alignment_context else {
+            self.run = None;
             self.unplaced_unmapped_record_count += 1;
             return Ok(());
         };
@@ -114,7 +127,28 @@ where
             Ordering::Greater => self.add_reference_sequences_until(reference_sequence_id),
         }
 
+        // Within a run of consecutive records assigned to the same bin, anchor the chunk at the
+        // run's start so that `Bin::add_chunk` coalesces the run into a single chunk spanning BGZF
+        // block boundaries. The linear index and metadata still see the record's own chunk.
+        let bin_id = reference_sequence::reg2bin(start, end, self.min_shift, self.depth);
+        let bin_chunk = match self.run {
+            Some(run)
+                if run.reference_sequence_id == reference_sequence_id && run.bin_id == bin_id =>
+            {
+                Chunk::new(run.start, chunk.end())
+            }
+            _ => {
+                self.run = Some(Run {
+                    reference_sequence_id,
+                    bin_id,
+                    start: chunk.start(),
+                });
+                chunk
+            }
+        };
+
         let reference_sequence = &mut self.reference_sequences[reference_sequence_id];
+        reference_sequence.add_chunk(bin_id, bin_chunk);
         reference_sequence.update(self.min_shift, self.depth, start, end, is_mapped, chunk);
 
         Ok(())
@@ -172,6 +206,7 @@ where
             header: None,
             reference_sequences: Vec::new(),
             unplaced_unmapped_record_count: 0,
+            run: None,
         }
     }
 }
@@ -185,6 +220,11 @@ mod tests {
         Bin, Metadata,
         index::{BinnedIndex, LinearIndex},
     };
+
+    // Builds a virtual position from a compressed (block) offset and an uncompressed offset.
+    fn vp(compressed: u64, uncompressed: u16) -> bgzf::VirtualPosition {
+        bgzf::VirtualPosition::try_from((compressed, uncompressed)).unwrap()
+    }
 
     #[test]
     fn test_default() {
@@ -359,6 +399,105 @@ mod tests {
                 bgzf::VirtualPosition::from(0),
                 bgzf::VirtualPosition::from(200),
             )]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_record_batches_chunks_across_blocks() -> Result<(), Box<dyn std::error::Error>> {
+        let mut indexer = Indexer::<LinearIndex>::default();
+
+        // Three consecutive records in the same leaf bin, with chunks in three different BGZF
+        // blocks.
+        indexer.add_record(
+            Some((0, Position::try_from(1)?, Position::try_from(100)?, true)),
+            Chunk::new(vp(0, 0), vp(0, 100)),
+        )?;
+        indexer.add_record(
+            Some((0, Position::try_from(200)?, Position::try_from(300)?, true)),
+            Chunk::new(vp(1, 0), vp(1, 100)),
+        )?;
+        indexer.add_record(
+            Some((0, Position::try_from(400)?, Position::try_from(500)?, true)),
+            Chunk::new(vp(2, 0), vp(2, 100)),
+        )?;
+
+        let index = indexer.build(1);
+        let reference_sequence = &index.reference_sequences()[0];
+
+        // The whole run is a single chunk spanning the three blocks.
+        assert_eq!(
+            reference_sequence.bins()[&4681].chunks(),
+            [Chunk::new(vp(0, 0), vp(2, 100))]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_record_keeps_per_record_linear_index() -> Result<(), Box<dyn std::error::Error>> {
+        let mut indexer = Indexer::<LinearIndex>::default();
+
+        // Two consecutive records in the same bin (585) but in different 16 KiB windows and BGZF
+        // blocks.
+        indexer.add_record(
+            Some((0, Position::try_from(1)?, Position::try_from(20000)?, true)),
+            Chunk::new(vp(0, 0), vp(0, 50)),
+        )?;
+        indexer.add_record(
+            Some((
+                0,
+                Position::try_from(40001)?,
+                Position::try_from(60000)?,
+                true,
+            )),
+            Chunk::new(vp(1, 0), vp(1, 50)),
+        )?;
+
+        let index = indexer.build(1);
+        let reference_sequence = &index.reference_sequences()[0];
+
+        // The run is batched into a single chunk in the bin...
+        assert_eq!(
+            reference_sequence.bins()[&585].chunks(),
+            [Chunk::new(vp(0, 0), vp(1, 50))]
+        );
+
+        // ...but the linear index records each record's own start, not the run's start.
+        assert_eq!(
+            reference_sequence.index().clone(),
+            [vp(0, 0), vp(0, 0), vp(1, 0), vp(1, 0)]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_record_ends_run_on_unplaced_record() -> Result<(), Box<dyn std::error::Error>> {
+        let mut indexer = Indexer::<LinearIndex>::default();
+
+        // Two records in the same leaf bin separated by an unplaced record; the run must not bridge
+        // the gap.
+        indexer.add_record(
+            Some((0, Position::try_from(1)?, Position::try_from(100)?, true)),
+            Chunk::new(vp(0, 0), vp(0, 100)),
+        )?;
+        indexer.add_record(None, Chunk::new(vp(1, 0), vp(1, 100)))?;
+        indexer.add_record(
+            Some((0, Position::try_from(1)?, Position::try_from(100)?, true)),
+            Chunk::new(vp(2, 0), vp(2, 100)),
+        )?;
+
+        let index = indexer.build(1);
+        let reference_sequence = &index.reference_sequences()[0];
+
+        assert_eq!(
+            reference_sequence.bins()[&4681].chunks(),
+            [
+                Chunk::new(vp(0, 0), vp(0, 100)),
+                Chunk::new(vp(2, 0), vp(2, 100)),
+            ]
         );
 
         Ok(())

--- a/noodles-csi/src/binning_index/indexer.rs
+++ b/noodles-csi/src/binning_index/indexer.rs
@@ -135,6 +135,10 @@ where
             self.add_reference_sequences_until(reference_sequence_count - 1);
         }
 
+        for reference_sequence in &mut self.reference_sequences {
+            reference_sequence.compact();
+        }
+
         let mut builder = Index::builder()
             .set_min_shift(self.min_shift)
             .set_depth(self.depth)
@@ -177,7 +181,10 @@ mod tests {
     use noodles_bgzf as bgzf;
 
     use super::*;
-    use crate::binning_index::index::reference_sequence::{Bin, Metadata, index::LinearIndex};
+    use crate::binning_index::index::reference_sequence::{
+        Bin, Metadata,
+        index::{BinnedIndex, LinearIndex},
+    };
 
     #[test]
     fn test_default() {
@@ -306,5 +313,54 @@ mod tests {
             .build();
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_build_compacts_bins_and_preserves_queries() -> Result<(), Box<dyn std::error::Error>> {
+        use noodles_core::region::Interval;
+
+        use crate::BinningIndex;
+
+        // Uses a binned index (as CSI does) to exercise the per-bin linear offset (loff) path
+        // under folding.
+        let mut indexer = Indexer::<BinnedIndex>::default();
+
+        // A record contained in one 16 KiB window is placed in leaf bin 4681.
+        indexer.add_record(
+            Some((0, Position::try_from(1)?, Position::try_from(100)?, true)),
+            Chunk::new(
+                bgzf::VirtualPosition::from(0),
+                bgzf::VirtualPosition::from(100),
+            ),
+        )?;
+
+        // A record spanning two 16 KiB windows is placed in the parent bin 585.
+        indexer.add_record(
+            Some((0, Position::try_from(1)?, Position::try_from(20000)?, true)),
+            Chunk::new(
+                bgzf::VirtualPosition::from(100),
+                bgzf::VirtualPosition::from(200),
+            ),
+        )?;
+
+        let index = indexer.build(1);
+
+        // The leaf bin was folded into its parent.
+        let reference_sequence = &index.reference_sequences()[0];
+        assert!(!reference_sequence.bins().contains_key(&4681));
+        assert!(reference_sequence.bins().contains_key(&585));
+
+        // A query over the folded leaf's region still returns the record's chunk.
+        let interval = Interval::from(Position::try_from(1)?..=Position::try_from(100)?);
+        let chunks = index.query(0, interval)?;
+        assert_eq!(
+            chunks,
+            [Chunk::new(
+                bgzf::VirtualPosition::from(0),
+                bgzf::VirtualPosition::from(200),
+            )]
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

`csi::binning_index::Indexer` builds spec-valid indices, but omits the two compaction behaviors htslib applies in `hts_idx_finish`. As a result it emits a larger index than `samtools index` for the same data — measured at ~1.3× on a deep-coverage WGS BAM and ~3.3× on a low-coverage (2×) WGS BAM — and carries more chunks per bin. This PR ports both behaviors so that every builder going through `Indexer` (BAI, CSI, TBI, and BCF's CSI) produces an index the same size and structure as samtools'. Query results are unchanged.

Both changes live in the shared `Indexer`, so all four formats benefit with no per-format code and no public API change.

## Change 1 — compact bins when building (`compress_binning`)

After the index is built, `ReferenceSequence::compact` folds any bin whose records span less than 64 KiB of compressed data into its parent bin, and merges chunks that share a BGZF block — mirroring htslib's `compress_binning` (`hts.c`). This drops the redundant fine-grained bins that the linear index already covers, which dominate the size for sparse data, and coalesces the chunk list for dense data.

The fold walks bins deepest-first (descending bin id) rather than level by level. Because `parent_id(b) = (b - 1) >> 3 < b`, descending order visits every bin after all of its descendants and before its parent, so a bin's span is final when tested and a parent is never removed before its children are considered — the same result as htslib's finest-to-coarsest cascade, but without needing the depth or the finest-level bin id, and touching each bin once. The linear index and per-bin linear offsets (CSI `loff`) are left untouched; folding is `loff`-safe because a parent's offset is already at or below its children's, and the CSI writer derives each surviving bin's `loff` from itself and its ancestors only.

## Change 2 — batch chunks of consecutive same-bin records (`hts_idx_push`)

`Indexer::add_record` now records a run of consecutive records assigned to the same bin as a single chunk spanning any BGZF block boundaries within the run, rather than one chunk per block — mirroring htslib's `hts_idx_push`. It anchors each record's chunk at the run's start so `Bin::add_chunk` coalesces the whole run; the linear index and metadata still see the record's own chunk.

Note on scope: the bundled `bam::fs::index` already avoids per-block splitting, because it advances each record's chunk start to the previous record's end (`start = end`), so a same-bin run coalesces across blocks automatically. So this change is effectively a no-op for the in-tree BAM indexer. Its value is (a) matching htslib's `hts_idx_push` batching semantics, and (b) making the `Indexer` robust for callers that compute per-record virtual positions independently: a record ending exactly at a BGZF block boundary otherwise starts a fresh chunk at every block. (A downstream index builder that computes chunk positions from block offsets saw ~18× index inflation on record-aligned BAMs from exactly this; this change eliminates that class of problem.) If you'd rather keep the `Indexer` minimal, Change 1 stands on its own — but I think Change 2 is worth it for htslib parity and downstream robustness.

## Results

Indexed with this branch vs `samtools index` (samtools 1.23.1) over the same file. "before" is the current `Indexer`; "this PR" is with both changes.

`HG03953.2x.bam` (4.15 GB, ~2× WGS subsampled from a deeper coverage 1000 genomes BAM):

| Metric | before | this PR | samtools |
| --- | ---: | ---: | ---: |
| BAI size | 9,020,384 B | 2,727,608 B | 2,727,608 B |
| Bins | 211,274 | 31,133 | 31,133 |
| Chunks | 351,867 | 48,639 | 48,639 |
| Linear intervals | 196,952 | 196,952 | 196,952 |
| n_no_coor | 8,282 | 8,282 | 8,282 |

`NA12813.bam` (67 GB, ~50× WGS, ~1.287B mapped reads):

| Metric | before | this PR | samtools |
| --- | ---: | ---: | ---: |
| BAI size | 12,313,472 B | 9,398,616 B | 9,398,616 B |
| Bins | 212,342 | 209,729 | 209,729 |
| Chunks | 555,608 | 374,736 | 374,736 |
| Linear intervals | 197,713 | 197,713 | 197,713 |
| n_no_coor | 352,968 | 352,968 | 352,968 |

In both cases the index is now the same size as samtools' and matches on every structural count. The reduction is all from Change 1: at low coverage many fine bins fall under the 64 KiB fold threshold and collapse into their parents (the dominant effect there); at high coverage fine bins hold enough data to be kept (as htslib intends) and the reduction comes from merging chunks that share a block.

The output is not byte-identical to samtools': the only difference is bin ordering within each reference (this PR keeps insertion order per #213; samtools writes hash order). Content, `idxstats`, and all queries are identical.

## Correctness & testing

Verified with each index swapped in under samtools, on both BAMs:

- `samtools idxstats` output identical (NA12813: 1,285,261,016 mapped / 1,881,446 unmapped).
- Region-query counts (`samtools view -c`) identical across a spread of regions (tiny windows, whole chromosomes, `chrM`, contig ends).
- Decoded records (`samtools view | md5`) byte-identical for the sampled regions.

New tests in the crate:

- Unit tests for the chunk helpers (`sort_chunks`, `compressed_span`, `merge_chunks_in_same_block`) and for `compact` (fold into an existing parent, keep a bin without a parent, keep a bin whose span is ≥ 64 KiB, never fold the root, and a cascade).
- Run batching: a run of same-bin records with chunks in different BGZF blocks collapses to one chunk; an unplaced record ends the run.
- A CSI (`BinnedIndex`) test builds through the `Indexer` so folding happens, then queries the folded-away leaf's region to confirm the linear-offset path stays correct.
- A test asserting the linear index records each record's own start (not the run's start) after batching.

Full workspace `cargo fmt --all -- --check`, `cargo clippy --all-features -- --deny warnings`, and `cargo test --all-features` pass, including the bam/tabix/bcf indexers that build through this `Indexer`. Changelog updated in `noodles-csi`.

## Notes

- Bin serialization stays in insertion order for determinism (#213); I did not sort bin ids on emit.
- As ever @zaeleus, I'd be happy to receive feedback and adjust this PR, and won't take offense if you decide to take the ideas from this PR and re-implement