### PR TITLE
fix: cram/crai/io/reader/record: Clear the line buffer between records

### DIFF
--- a/noodles-cram/CHANGELOG.md
+++ b/noodles-cram/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+  * cram/crai/io/reader/record: Clear the line buffer between records.
+
+    `read_index` passes a single buffer to `read_record`, which appends to it
+    rather than replacing its contents. Each line was concatenated onto the
+    previous one, causing an index with more than one record to fail to parse.
+
 ## 0.96.0 - 2026-07-24
 
 ### Changed

--- a/noodles-cram/src/crai/async/io/reader.rs
+++ b/noodles-cram/src/crai/async/io/reader.rs
@@ -153,6 +153,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_read_index_with_multiple_records() -> Result<(), Box<dyn std::error::Error>> {
+        let data = b"0\t10946\t6765\t17711\t233\t317811\n1\t17\t21\t34\t55\t89\n";
+
+        let mut reader = &data[..];
+        let mut buf = String::new();
+        let actual = read_index(&mut reader, &mut buf).await?;
+
+        let expected = vec![
+            Record::new(Some(0), Position::new(10946), 6765, 17711, 233, 317811),
+            Record::new(Some(1), Position::new(17), 21, 34, 55, 89),
+        ];
+
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_read_line() -> io::Result<()> {
         async fn t(buf: &mut String, mut src: &[u8], expected: &str) -> io::Result<()> {
             buf.clear();

--- a/noodles-cram/src/crai/async/io/reader/record.rs
+++ b/noodles-cram/src/crai/async/io/reader/record.rs
@@ -11,6 +11,8 @@ pub(super) async fn read_record<R>(
 where
     R: AsyncBufRead + Unpin,
 {
+    buf.clear();
+
     match read_line(reader, buf).await? {
         0 => Ok(0),
         n => {

--- a/noodles-cram/src/crai/io/reader.rs
+++ b/noodles-cram/src/crai/io/reader.rs
@@ -139,6 +139,24 @@ mod tests {
     }
 
     #[test]
+    fn test_read_index_with_multiple_records() -> Result<(), Box<dyn std::error::Error>> {
+        let data = b"0\t10946\t6765\t17711\t233\t317811\n1\t17\t21\t34\t55\t89\n";
+
+        let mut reader = &data[..];
+        let mut buf = String::new();
+        let actual = read_index(&mut reader, &mut buf)?;
+
+        let expected = vec![
+            Record::new(Some(0), Position::new(10946), 6765, 17711, 233, 317811),
+            Record::new(Some(1), Position::new(17), 21, 34, 55, 89),
+        ];
+
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_read_line() -> io::Result<()> {
         fn t(buf: &mut String, mut src: &[u8], expected: &str) -> io::Result<()> {
             buf.clear();

--- a/noodles-cram/src/crai/io/reader/record.rs
+++ b/noodles-cram/src/crai/io/reader/record.rs
@@ -16,6 +16,8 @@ pub(super) fn read_record<R>(
 where
     R: BufRead,
 {
+    buf.clear();
+
     match read_line(reader, buf)? {
         0 => Ok(0),
         n => {


### PR DESCRIPTION
`crai::io::reader::read_index` passes a single `String` through the free `read_record`, which appends to it via `BufRead::read_line` rather than replacing its contents. Every line after the first is concatenated onto the previous one, so reading an index with more than one record fails:

```rust
let data = b"0\t10946\t6765\t17711\t233\t317811\n1\t17\t21\t34\t55\t89\n";
let index = crai::io::Reader::new(&data[..]).read_index()?;
```

```
Err(Custom { kind: InvalidData, error: ParseIntError { kind: InvalidDigit } })
```

The second record is parsed from `0\t10946\t6765\t17711\t233\t3178111\t17\t21\t34\t55\t89`, whose leading field is no longer an integer.

`Reader::read_record` clears the buffer before delegating, so only the `read_index` path is affected. In practice that means `crai::fs::read` fails on any CRAI describing more than one slice — which is most real files. I ran into it reading CRAMs through a downstream crate, where it surfaced as `invalid digit found in string`.

Both existing `test_read_index` tests use a single-record index, so nothing caught this. The fix clears the buffer in `read_record` itself, for the sync and async readers, and adds two-record regression tests alongside the existing ones. I confirmed the new tests fail without the fix and pass with it.

I put the `buf.clear()` in the free `read_record` rather than in `read_index`'s loop so the buffer contract holds for both callers; that leaves the existing clear in `Reader::read_record` redundant, and I left it in place to keep the diff small. Happy to move the clear to the loop, or drop the now-redundant one, if you'd prefer it elsewhere.