### PR TITLE
cram/io: Increase the visibility of the variable-length integer codecs

### DIFF
--- a/noodles-cram/CHANGELOG.md
+++ b/noodles-cram/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Added
+
+  * cram/io/reader: Add variable-length integer readers (`num::read_itf8`,
+    `num::read_itf8_as`, `num::read_ltf8`, `num::read_ltf8_as`,
+    `num::read_uint7`, and `num::read_uint7_as`) ([#411]).
+
+  * cram/io/writer: Add variable-length integer writers (`num::write_itf8`,
+    `num::write_ltf8`, and `num::write_uint7`) ([#411]).
+
+[#411]: https://github.com/zaeleus/noodles/pull/411
+
 ### Changed
 
   * cram: Update to lzma-rust2 0.20.0.

--- a/noodles-cram/src/io/reader.rs
+++ b/noodles-cram/src/io/reader.rs
@@ -4,7 +4,7 @@ mod builder;
 pub(crate) mod collections;
 pub(crate) mod container;
 pub mod header;
-pub(crate) mod num;
+pub mod num;
 pub(crate) mod query;
 mod records;
 

--- a/noodles-cram/src/io/reader/num.rs
+++ b/noodles-cram/src/io/reader/num.rs
@@ -1,3 +1,5 @@
+//! CRAM variable-length integer readers.
+
 mod itf8;
 mod ltf8;
 mod vlq;

--- a/noodles-cram/src/io/reader/num/itf8.rs
+++ b/noodles-cram/src/io/reader/num/itf8.rs
@@ -5,6 +5,17 @@ use std::{
 
 use super::{read_u8, read_u16_be, read_u24_be, read_u32_be};
 
+/// Reads an ITF-8 integer.
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::io::reader::num::read_itf8;
+///
+/// let mut src = &[0x87, 0x55][..];
+/// assert_eq!(read_itf8(&mut src)?, 1877);
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn read_itf8<R>(reader: &mut R) -> io::Result<i32>
 where
     R: Read,
@@ -30,6 +41,17 @@ where
     Ok(n as i32)
 }
 
+/// Reads an ITF-8 integer and converts it to `N`.
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::io::reader::num::read_itf8_as;
+///
+/// let mut src = &[0x87, 0x55][..];
+/// assert_eq!(read_itf8_as::<_, u16>(&mut src)?, 1877);
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn read_itf8_as<R, N>(reader: &mut R) -> io::Result<N>
 where
     R: Read,

--- a/noodles-cram/src/io/reader/num/ltf8.rs
+++ b/noodles-cram/src/io/reader/num/ltf8.rs
@@ -5,6 +5,17 @@ use std::{
 
 use super::{read_u8, read_u16_be, read_u24_be, read_u32_be};
 
+/// Reads an LTF-8 integer.
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::io::reader::num::read_ltf8;
+///
+/// let mut src = &[0x80, 0xaa][..];
+/// assert_eq!(read_ltf8(&mut src)?, 170);
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn read_ltf8<R>(reader: &mut R) -> io::Result<i64>
 where
     R: Read,
@@ -40,6 +51,17 @@ where
     Ok(n as i64)
 }
 
+/// Reads an LTF-8 integer and converts it to `N`.
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::io::reader::num::read_ltf8_as;
+///
+/// let mut src = &[0x80, 0xaa][..];
+/// assert_eq!(read_ltf8_as::<_, u16>(&mut src)?, 170);
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn read_ltf8_as<R, N>(reader: &mut R) -> io::Result<N>
 where
     R: Read,

--- a/noodles-cram/src/io/reader/num/vlq.rs
+++ b/noodles-cram/src/io/reader/num/vlq.rs
@@ -7,6 +7,17 @@ use super::read_u8;
 
 const MAX_SIZE: usize = 5;
 
+/// Reads a 7-bit variable-length quantity (`uint7`).
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::io::reader::num::read_uint7;
+///
+/// let mut src = &[0x81, 0x00][..];
+/// assert_eq!(read_uint7(&mut src)?, 128);
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn read_uint7<R>(reader: &mut R) -> io::Result<u32>
 where
     R: Read,
@@ -34,6 +45,17 @@ where
     Ok(n)
 }
 
+/// Reads a 7-bit variable-length quantity (`uint7`) and converts it to `N`.
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::io::reader::num::read_uint7_as;
+///
+/// let mut src = &[0x81, 0x00][..];
+/// assert_eq!(read_uint7_as::<_, u16>(&mut src)?, 128);
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn read_uint7_as<R, N>(reader: &mut R) -> io::Result<N>
 where
     R: Read,

--- a/noodles-cram/src/io/writer.rs
+++ b/noodles-cram/src/io/writer.rs
@@ -5,7 +5,7 @@ mod collections;
 pub(crate) mod container;
 mod context;
 pub(crate) mod header;
-pub(crate) mod num;
+pub mod num;
 pub(crate) mod record;
 
 use std::io::{self, Write};

--- a/noodles-cram/src/io/writer/num.rs
+++ b/noodles-cram/src/io/writer/num.rs
@@ -1,3 +1,5 @@
+//! CRAM variable-length integer writers.
+
 mod itf8;
 mod ltf8;
 mod vlq;

--- a/noodles-cram/src/io/writer/num/itf8.rs
+++ b/noodles-cram/src/io/writer/num/itf8.rs
@@ -1,5 +1,17 @@
 use std::io::{self, Write};
 
+/// Writes an ITF-8 integer.
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::io::writer::num::write_itf8;
+///
+/// let mut dst = Vec::new();
+/// write_itf8(&mut dst, 1877)?;
+/// assert_eq!(dst, [0x87, 0x55]);
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn write_itf8<W>(writer: &mut W, n: i32) -> io::Result<()>
 where
     W: Write,

--- a/noodles-cram/src/io/writer/num/ltf8.rs
+++ b/noodles-cram/src/io/writer/num/ltf8.rs
@@ -1,5 +1,17 @@
 use std::io::{self, Write};
 
+/// Writes an LTF-8 integer.
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::io::writer::num::write_ltf8;
+///
+/// let mut dst = Vec::new();
+/// write_ltf8(&mut dst, 170)?;
+/// assert_eq!(dst, [0x80, 0xaa]);
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn write_ltf8<W>(writer: &mut W, n: i64) -> io::Result<()>
 where
     W: Write,

--- a/noodles-cram/src/io/writer/num/vlq.rs
+++ b/noodles-cram/src/io/writer/num/vlq.rs
@@ -1,5 +1,17 @@
 use std::io::{self, Write};
 
+/// Writes a 7-bit variable-length quantity (`uint7`).
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::io::writer::num::write_uint7;
+///
+/// let mut dst = Vec::new();
+/// write_uint7(&mut dst, 128)?;
+/// assert_eq!(dst, [0x81, 0x00]);
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn write_uint7<W>(writer: &mut W, mut n: u32) -> io::Result<()>
 where
     W: Write,


### PR DESCRIPTION
`cram::io::reader::num` and `cram::io::writer::num` are `pub(crate)`, but the readers and writers they export (`read_itf8`, `read_itf8_as`, `read_ltf8`, `read_ltf8_as`, `read_uint7`, `read_uint7_as`, `write_itf8`, `write_ltf8`, `write_uint7`) are already `pub` inside those modules. The module visibility is what keeps them out of the public API.

ITF-8 and LTF-8 are named and defined by the CRAM specification independently of the container format, so they are part of the format rather than an implementation detail of this crate. Tooling built alongside noodles (container validators, index inspectors, format converters) currently has to reimplement them byte for byte.

This changes the two module declarations to `pub` and adds the documentation the public API requires (`missing_docs` is denied in CI), including an example per function. No signatures change.

This mirrors `sam::io::writer::record::write_cigar`, made public in #247 for the same reason.

Note on overlap: #380 also modifies `io/reader/num.rs` and `io/writer/num.rs`. This change is independent of that work: it only flips the two module declarations and documents what those modules already export, so it applies cleanly before or after it. It targets CRAM 3.0/3.1 as currently supported and makes no claim about any other version.

Split into three commits; each builds and passes `cargo fmt -- --check`, `cargo clippy --all-features -- --deny warnings`, and `cargo test --all-features` on its own.
