### PR TITLE
cram/codecs: Increase the visibility of the rANS decoders and encoders

### DIFF
--- a/noodles-cram/CHANGELOG.md
+++ b/noodles-cram/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+  * cram/codecs/rans_4x8: Add decoder (`decode`) and encoder (`encode`)
+    ([#412]).
+
+  * cram/codecs/rans_nx16: Add decoder (`decode`) and encoder (`encode`)
+    ([#412]).
+
+[#412]: https://github.com/zaeleus/noodles/pull/412
+
 ### Changed
 
   * cram: Update to lzma-rust2 0.20.0.

--- a/noodles-cram/src/codecs/rans_4x8.rs
+++ b/noodles-cram/src/codecs/rans_4x8.rs
@@ -4,8 +4,7 @@ mod decode;
 mod encode;
 mod order;
 
-pub use self::order::Order;
-pub(crate) use self::{decode::decode, encode::encode};
+pub use self::{decode::decode, encode::encode, order::Order};
 
 // § 2.2 "rANS entropy encoding" (2023-03-15)
 const ALPHABET_SIZE: usize = 256; // b

--- a/noodles-cram/src/codecs/rans_4x8/decode.rs
+++ b/noodles-cram/src/codecs/rans_4x8/decode.rs
@@ -8,6 +8,19 @@ use self::header::read_header;
 use super::{LOWER_BOUND, Order, STATE_COUNT};
 use crate::io::reader::num::{read_u8, read_u32_le};
 
+/// Decodes a rANS 4x8 stream.
+///
+/// The order and uncompressed size are read from the stream header.
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::codecs::rans_4x8::{Order, decode, encode};
+///
+/// let src = encode(Order::Zero, b"noodles")?;
+/// assert_eq!(decode(&src)?, b"noodles");
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn decode(mut src: &[u8]) -> io::Result<Vec<u8>> {
     let (order, _, uncompressed_size) = read_header(&mut src)?;
 

--- a/noodles-cram/src/codecs/rans_4x8/encode.rs
+++ b/noodles-cram/src/codecs/rans_4x8/encode.rs
@@ -9,6 +9,17 @@ use crate::io::writer::num::{write_u8, write_u32_le};
 use self::header::write_header;
 use super::{LOWER_BOUND, Order, STATE_COUNT};
 
+/// Encodes a buffer as a rANS 4x8 stream.
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::codecs::rans_4x8::{Order, decode, encode};
+///
+/// let src = encode(Order::Zero, b"noodles")?;
+/// assert_eq!(decode(&src)?, b"noodles");
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn encode(order: Order, src: &[u8]) -> io::Result<Vec<u8>> {
     match order {
         Order::Zero => order_0::encode(src),

--- a/noodles-cram/src/codecs/rans_nx16.rs
+++ b/noodles-cram/src/codecs/rans_nx16.rs
@@ -4,8 +4,7 @@ pub(crate) mod decode;
 pub(crate) mod encode;
 mod flags;
 
-pub use self::flags::Flags;
-pub(crate) use self::{decode::decode, encode::encode};
+pub use self::{decode::decode, encode::encode, flags::Flags};
 
 const ALPHABET_SIZE: usize = 256;
 

--- a/noodles-cram/src/codecs/rans_nx16/decode.rs
+++ b/noodles-cram/src/codecs/rans_nx16/decode.rs
@@ -9,6 +9,20 @@ use std::io;
 use super::{ALPHABET_SIZE, Flags};
 use crate::io::reader::num::{read_u8, read_u32_le, read_uint7_as};
 
+/// Decodes a rANS Nx16 stream.
+///
+/// `uncompressed_size` is only used when the stream does not store one itself, i.e., when
+/// `Flags::NO_SIZE` is set.
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::codecs::rans_nx16::{Flags, decode, encode};
+///
+/// let src = encode(Flags::empty(), b"noodles")?;
+/// assert_eq!(decode(&src, 7)?, b"noodles");
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn decode(mut src: &[u8], mut uncompressed_size: usize) -> io::Result<Vec<u8>> {
     let flags = read_flags(&mut src)?;
 

--- a/noodles-cram/src/codecs/rans_nx16/encode.rs
+++ b/noodles-cram/src/codecs/rans_nx16/encode.rs
@@ -15,6 +15,17 @@ use crate::io::writer::num::{write_u8, write_u32_le, write_uint7};
 // § 3 "rANS Nx16" (2023-03-15): "The lower-bound and initial encoder state _L_ is [...] 0x8000."
 const LOWER_BOUND: u32 = 0x8000;
 
+/// Encodes a buffer as a rANS Nx16 stream.
+///
+/// # Examples
+///
+/// ```
+/// use noodles_cram::codecs::rans_nx16::{Flags, decode, encode};
+///
+/// let src = encode(Flags::empty(), b"noodles")?;
+/// assert_eq!(decode(&src, 7)?, b"noodles");
+/// # Ok::<_, std::io::Error>(())
+/// ```
 pub fn encode(mut flags: Flags, src: &[u8]) -> io::Result<Vec<u8>> {
     let mut src = Cow::from(src);
     let mut dst = Vec::new();


### PR DESCRIPTION
`codecs::rans_4x8` and `codecs::rans_nx16` are public modules, but their `decode` and `encode` functions are `pub(crate)`. What the modules currently export is `Order` and `Flags`: the parameter types for operations that cannot be called.

rANS 4x8 and rANS Nx16 are specified by CRAMcodecs independently of the CRAM container format, and htscodecs ships them as a standalone library used outside CRAM. There is no pure-Rust implementation of either that is usable as a library today.

This changes the two re-exports to `pub` and adds the documentation the public API requires (`missing_docs` is denied in CI), with a round-trip example per function. No signatures change, and the `decode`/`encode` modules themselves stay crate-private, so the internal helpers next to them (`state_step`, `bit_pack`, and so on) are not exposed.

Split into three commits; each builds and passes `cargo fmt -- --check`, `cargo clippy --all-features -- --deny warnings`, and `cargo test --all-features` on its own.

Kept separate from #411 on purpose: two modules, two reasons, and a refusal on one should not carry the other.
