### PR TITLE
vcf: Add an option to write header records in the order they were added

### DIFF
--- a/noodles-vcf/CHANGELOG.md
+++ b/noodles-vcf/CHANGELOG.md
@@ -11,11 +11,28 @@
   * vcf/variant/record_buf/alternate_bases: Implement `Extend<String>` and
     `FromIterator<String>`.
 
+  * vcf/header: Add record order (`Header::record_order`).
+
+    This is the keys of the records in the order they were added. Records added
+    using the mutable accessors, e.g., `Header::infos_mut`, are not tracked.
+
+  * vcf/io/writer: Add header record order option
+    (`writer::Builder::set_record_order`).
+
+    `RecordOrder::Grouped` (default) groups records by category, which is the
+    previous behavior. `RecordOrder::AsAdded` follows `Header::record_order`,
+    which makes reading and writing a header idempotent.
+
 ### Changed
 
   * vcf/record/samples/series/value/genotype: Return error on empty input.
 
     Empty inputs now return `io::ErrorKind::UnexpectedEof`.
+
+  * vcf/header: Exclude the record order from `Header` equality.
+
+    `PartialEq` is now implemented manually. Two headers with the same records
+    remain equal regardless of the order they were added in.
 
 ## 0.93.0 - 2026-08-21
 
@@ -1277,7 +1294,6 @@
   * vcf/record/genotypes/genotype/field: Remove `Field`.
 
     Use `(Key, Option<Value>)` instead.
-
 
 ## 0.23.0 - 2022-11-29
 

--- a/noodles-vcf/src/header.rs
+++ b/noodles-vcf/src/header.rs
@@ -4,11 +4,12 @@ mod builder;
 pub mod file_format;
 pub mod parser;
 pub mod record;
+mod record_key;
 pub mod string_maps;
 
 pub use self::{
     builder::Builder, file_format::FileFormat, parser::ParseError, parser::Parser, record::Record,
-    string_maps::StringMaps,
+    record_key::RecordKey, string_maps::StringMaps,
 };
 
 use std::{hash::Hash, str::FromStr};
@@ -42,7 +43,7 @@ pub type SampleNames = IndexSet<String>;
 pub type OtherRecords = IndexMap<record::key::Other, record::value::Collection>;
 
 /// A VCF header.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq)]
 pub struct Header {
     file_format: FileFormat,
     infos: Infos,
@@ -53,6 +54,23 @@ pub struct Header {
     sample_names: SampleNames,
     other_records: OtherRecords,
     string_maps: StringMaps,
+    record_order: Vec<RecordKey>,
+}
+
+// The record order describes how the records were laid out in the source, not what they are. Two
+// headers with the same records are equal regardless of the order they were added in.
+impl PartialEq for Header {
+    fn eq(&self, other: &Self) -> bool {
+        self.file_format == other.file_format
+            && self.infos == other.infos
+            && self.filters == other.filters
+            && self.formats == other.formats
+            && self.alternative_alleles == other.alternative_alleles
+            && self.contigs == other.contigs
+            && self.sample_names == other.sample_names
+            && self.other_records == other.other_records
+            && self.string_maps == other.string_maps
+    }
 }
 
 impl Header {
@@ -429,6 +447,46 @@ impl Header {
     /// ```
     pub fn other_records_mut(&mut self) -> &mut OtherRecords {
         &mut self.other_records
+    }
+
+    /// Returns the order in which records were added to the header.
+    ///
+    /// Records added using the mutable accessors, e.g., [`Self::infos_mut`], are not tracked. Keys
+    /// that no longer resolve to a record are ignored by consumers, and records missing from this
+    /// list are handled as if they were added last.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf::{
+    ///     self as vcf,
+    ///     header::{
+    ///         record::value::{Map, map::Filter},
+    ///         RecordKey,
+    ///     },
+    /// };
+    ///
+    /// let header = vcf::Header::builder()
+    ///     .add_filter("q10", Map::<Filter>::new("Quality below 10"))
+    ///     .build();
+    ///
+    /// assert_eq!(header.record_order(), [RecordKey::Filter(String::from("q10"))]);
+    /// ```
+    pub fn record_order(&self) -> &[RecordKey] {
+        &self.record_order
+    }
+
+    /// Returns a mutable reference to the order in which records were added to the header.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf as vcf;
+    /// let mut header = vcf::Header::default();
+    /// header.record_order_mut().clear();
+    /// ```
+    pub fn record_order_mut(&mut self) -> &mut Vec<RecordKey> {
+        &mut self.record_order
     }
 
     /// Returns a collection of header values with the given key.

--- a/noodles-vcf/src/header/builder.rs
+++ b/noodles-vcf/src/header/builder.rs
@@ -1,6 +1,6 @@
 use super::{
     AlternativeAlleles, Contigs, FileFormat, Filters, Formats, Header, Infos, OtherRecords,
-    SampleNames, StringMaps,
+    RecordKey, SampleNames, StringMaps,
     record::{
         self,
         value::{
@@ -23,6 +23,7 @@ pub struct Builder {
     contigs: Contigs,
     sample_names: SampleNames,
     other_records: OtherRecords,
+    record_order: Vec<RecordKey>,
 }
 
 impl Builder {
@@ -70,7 +71,12 @@ impl Builder {
     where
         I: Into<String>,
     {
-        self.infos.insert(id.into(), info);
+        let id = id.into();
+
+        if self.infos.insert(id.clone(), info).is_none() {
+            self.record_order.push(RecordKey::Info(id));
+        }
+
         self
     }
 
@@ -95,7 +101,12 @@ impl Builder {
     where
         I: Into<String>,
     {
-        self.filters.insert(id.into(), filter);
+        let id = id.into();
+
+        if self.filters.insert(id.clone(), filter).is_none() {
+            self.record_order.push(RecordKey::Filter(id));
+        }
+
         self
     }
 
@@ -125,7 +136,12 @@ impl Builder {
     where
         I: Into<String>,
     {
-        self.formats.insert(id.into(), format);
+        let id = id.into();
+
+        if self.formats.insert(id.clone(), format).is_none() {
+            self.record_order.push(RecordKey::Format(id));
+        }
+
         self
     }
 
@@ -157,8 +173,15 @@ impl Builder {
     where
         I: Into<String>,
     {
-        self.alternative_alleles
-            .insert(id.into(), alternative_allele);
+        let id = id.into();
+
+        if self
+            .alternative_alleles
+            .insert(id.clone(), alternative_allele)
+            .is_none()
+        {
+            self.record_order.push(RecordKey::AlternativeAllele(id));
+        }
 
         self
     }
@@ -184,7 +207,12 @@ impl Builder {
     where
         I: Into<String>,
     {
-        self.contigs.insert(id.into(), contig);
+        let id = id.into();
+
+        if self.contigs.insert(id.clone(), contig).is_none() {
+            self.record_order.push(RecordKey::Contig(id));
+        }
+
         self
     }
 
@@ -265,6 +293,10 @@ impl Builder {
         key: record::key::Other,
         value: record::Value,
     ) -> Result<Self, super::record::value::collection::AddError> {
+        if !self.other_records.contains_key(&key) {
+            self.record_order.push(RecordKey::Other(key.clone()));
+        }
+
         let collection = self
             .other_records
             .entry(key)
@@ -297,6 +329,7 @@ impl Builder {
             sample_names: self.sample_names,
             other_records: self.other_records,
             string_maps: StringMaps::default(),
+            record_order: self.record_order,
         }
     }
 }

--- a/noodles-vcf/src/header/parser.rs
+++ b/noodles-vcf/src/header/parser.rs
@@ -12,7 +12,7 @@ use indexmap::IndexMap;
 pub(super) use self::record::parse_record;
 pub use self::{builder::Builder, entry::Entry, file_format_option::FileFormatOption};
 use super::{
-    AlternativeAlleles, Contigs, Filters, Formats, Header, Infos, OtherRecords, Record,
+    AlternativeAlleles, Contigs, Filters, Formats, Header, Infos, OtherRecords, Record, RecordKey,
     SampleNames, StringMaps,
     file_format::FileFormat,
     record::value::{
@@ -42,6 +42,7 @@ pub struct Parser {
     contigs: Contigs,
     sample_names: SampleNames,
     other_records: OtherRecords,
+    record_order: Vec<RecordKey>,
 }
 
 impl Parser {
@@ -125,14 +126,34 @@ impl Parser {
 
         match record {
             Record::FileFormat(_) => Err(ParseError::UnexpectedFileFormat),
-            Record::Info(id, info) => try_insert_info(&mut self.infos, id, info),
-            Record::Filter(id, filter) => try_insert_filter(&mut self.filters, id, filter),
-            Record::Format(id, format) => try_insert_format(&mut self.formats, id, format),
+            Record::Info(id, info) => {
+                self.record_order.push(RecordKey::Info(id.clone()));
+                try_insert_info(&mut self.infos, id, info)
+            }
+            Record::Filter(id, filter) => {
+                self.record_order.push(RecordKey::Filter(id.clone()));
+                try_insert_filter(&mut self.filters, id, filter)
+            }
+            Record::Format(id, format) => {
+                self.record_order.push(RecordKey::Format(id.clone()));
+                try_insert_format(&mut self.formats, id, format)
+            }
             Record::AlternativeAllele(id, alternative_allele) => {
+                self.record_order
+                    .push(RecordKey::AlternativeAllele(id.clone()));
                 try_insert_alternative_allele(&mut self.alternative_alleles, id, alternative_allele)
             }
-            Record::Contig(id, contig) => try_insert_contig(&mut self.contigs, id, contig),
-            Record::Other(key, value) => insert_other_record(&mut self.other_records, key, value),
+            Record::Contig(id, contig) => {
+                self.record_order.push(RecordKey::Contig(id.clone()));
+                try_insert_contig(&mut self.contigs, id, contig)
+            }
+            Record::Other(key, value) => {
+                if !self.other_records.contains_key(&key) {
+                    self.record_order.push(RecordKey::Other(key.clone()));
+                }
+
+                insert_other_record(&mut self.other_records, key, value)
+            }
         }
     }
 
@@ -168,6 +189,7 @@ impl Parser {
                 sample_names: self.sample_names,
                 other_records: self.other_records,
                 string_maps: StringMaps::default(),
+                record_order: self.record_order,
             }),
         }
     }

--- a/noodles-vcf/src/header/record_key.rs
+++ b/noodles-vcf/src/header/record_key.rs
@@ -1,0 +1,21 @@
+use super::record::key::Other;
+
+/// A key that identifies a VCF header record.
+///
+/// This is used to track the order in which records were added to a [`crate::Header`], which is
+/// otherwise only retained within a category.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum RecordKey {
+    /// An `ALT` record.
+    AlternativeAllele(String),
+    /// A `contig` record.
+    Contig(String),
+    /// A `FILTER` record.
+    Filter(String),
+    /// A `FORMAT` record.
+    Format(String),
+    /// An `INFO` record.
+    Info(String),
+    /// A nonstandard record.
+    Other(Other),
+}

--- a/noodles-vcf/src/io/writer.rs
+++ b/noodles-vcf/src/io/writer.rs
@@ -3,10 +3,11 @@
 mod builder;
 mod header;
 mod record;
+mod record_order;
 
 use std::io::{self, Write};
 
-pub use self::builder::Builder;
+pub use self::{builder::Builder, record_order::RecordOrder};
 use self::{header::write_header, record::write_record};
 use crate::{Header, Record};
 
@@ -55,6 +56,7 @@ use crate::{Header, Record};
 #[derive(Debug)]
 pub struct Writer<W> {
     inner: W,
+    record_order: RecordOrder,
 }
 
 impl<W> Writer<W>
@@ -70,7 +72,10 @@ where
     /// let writer = vcf::io::Writer::new(Vec::new());
     /// ```
     pub fn new(inner: W) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            record_order: RecordOrder::default(),
+        }
     }
 
     /// Returns a reference to the underlying writer.
@@ -127,7 +132,7 @@ where
     /// # Ok::<(), io::Error>(())
     /// ```
     pub fn write_header(&mut self, header: &Header) -> io::Result<()> {
-        write_header(&mut self.inner, header)
+        write_header(&mut self.inner, header, self.record_order)
     }
 
     /// Writes a VCF record.

--- a/noodles-vcf/src/io/writer/builder.rs
+++ b/noodles-vcf/src/io/writer/builder.rs
@@ -6,13 +6,14 @@ use std::{
 
 use noodles_bgzf as bgzf;
 
-use super::Writer;
+use super::{RecordOrder, Writer};
 use crate::io::CompressionMethod;
 
 /// A VCF writer builder.
 #[derive(Debug, Default)]
 pub struct Builder {
     compression_method: Option<CompressionMethod>,
+    record_order: RecordOrder,
 }
 
 impl Builder {
@@ -26,6 +27,21 @@ impl Builder {
     /// ```
     pub fn set_compression_method(mut self, compression_method: CompressionMethod) -> Self {
         self.compression_method = Some(compression_method);
+        self
+    }
+
+    /// Sets the order in which header records are written.
+    ///
+    /// The default is [`RecordOrder::Grouped`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_vcf::io::writer::{Builder, RecordOrder};
+    /// let builder = Builder::default().set_record_order(RecordOrder::AsAdded);
+    /// ```
+    pub fn set_record_order(mut self, record_order: RecordOrder) -> Self {
+        self.record_order = record_order;
         self
     }
 
@@ -77,6 +93,8 @@ impl Builder {
             Some(CompressionMethod::None) | None => Box::new(BufWriter::new(writer)),
         };
 
-        Writer::new(inner)
+        let mut writer = Writer::new(inner);
+        writer.record_order = self.record_order;
+        writer
     }
 }

--- a/noodles-vcf/src/io/writer/header.rs
+++ b/noodles-vcf/src/io/writer/header.rs
@@ -1,20 +1,45 @@
 mod record;
 
-use std::io::{self, Write};
+use std::{
+    collections::HashSet,
+    io::{self, Write},
+};
 
 use self::record::{
     write_alternative_allele, write_contig, write_file_format, write_filter, write_format,
     write_info, write_other,
 };
-use crate::{Header, header::SampleNames};
+use super::RecordOrder;
+use crate::{
+    Header,
+    header::{RecordKey, SampleNames, record::key::Other},
+};
 
-pub(super) fn write_header<W>(writer: &mut W, header: &Header) -> io::Result<()>
+pub(super) fn write_header<W>(
+    writer: &mut W,
+    header: &Header,
+    record_order: RecordOrder,
+) -> io::Result<()>
+where
+    W: Write,
+{
+    write_file_format(writer, header.file_format())?;
+
+    match record_order {
+        RecordOrder::Grouped => write_grouped_records(writer, header)?,
+        RecordOrder::AsAdded => write_added_records(writer, header)?,
+    }
+
+    write_column_names(writer, header.sample_names())?;
+
+    Ok(())
+}
+
+fn write_grouped_records<W>(writer: &mut W, header: &Header) -> io::Result<()>
 where
     W: Write,
 {
     let file_format = header.file_format();
-
-    write_file_format(writer, file_format)?;
 
     for (id, info) in header.infos() {
         write_info(writer, id, info)?;
@@ -40,7 +65,103 @@ where
         write_other(writer, file_format, key, collection)?;
     }
 
-    write_column_names(writer, header.sample_names())?;
+    Ok(())
+}
+
+/// Writes the records in the order they were added, followed by any record the header does not
+/// track, grouped by category.
+///
+/// A key that no longer resolves to a record is skipped, which is what makes this tolerant of
+/// headers mutated through, e.g., `Header::infos_mut`.
+fn write_added_records<W>(writer: &mut W, header: &Header) -> io::Result<()>
+where
+    W: Write,
+{
+    let file_format = header.file_format();
+
+    let mut infos = HashSet::new();
+    let mut filters = HashSet::new();
+    let mut formats = HashSet::new();
+    let mut alternative_alleles = HashSet::new();
+    let mut contigs = HashSet::new();
+    let mut others: HashSet<&Other> = HashSet::new();
+
+    for key in header.record_order() {
+        match key {
+            RecordKey::Info(id) => {
+                if let Some(info) = header.infos().get(id.as_str()) {
+                    write_info(writer, id, info)?;
+                    infos.insert(id.as_str());
+                }
+            }
+            RecordKey::Filter(id) => {
+                if let Some(filter) = header.filters().get(id.as_str()) {
+                    write_filter(writer, id, filter)?;
+                    filters.insert(id.as_str());
+                }
+            }
+            RecordKey::Format(id) => {
+                if let Some(format) = header.formats().get(id.as_str()) {
+                    write_format(writer, id, format)?;
+                    formats.insert(id.as_str());
+                }
+            }
+            RecordKey::AlternativeAllele(id) => {
+                if let Some(alternative_allele) = header.alternative_alleles().get(id.as_str()) {
+                    write_alternative_allele(writer, id, alternative_allele)?;
+                    alternative_alleles.insert(id.as_str());
+                }
+            }
+            RecordKey::Contig(id) => {
+                if let Some(contig) = header.contigs().get(id.as_str()) {
+                    write_contig(writer, id, contig)?;
+                    contigs.insert(id.as_str());
+                }
+            }
+            RecordKey::Other(key) => {
+                if let Some(collection) = header.other_records().get(key) {
+                    write_other(writer, file_format, key, collection)?;
+                    others.insert(key);
+                }
+            }
+        }
+    }
+
+    for (id, info) in header.infos() {
+        if !infos.contains(id.as_str()) {
+            write_info(writer, id, info)?;
+        }
+    }
+
+    for (id, filter) in header.filters() {
+        if !filters.contains(id.as_str()) {
+            write_filter(writer, id, filter)?;
+        }
+    }
+
+    for (id, format) in header.formats() {
+        if !formats.contains(id.as_str()) {
+            write_format(writer, id, format)?;
+        }
+    }
+
+    for (id, alternative_allele) in header.alternative_alleles() {
+        if !alternative_alleles.contains(id.as_str()) {
+            write_alternative_allele(writer, id, alternative_allele)?;
+        }
+    }
+
+    for (id, contig) in header.contigs() {
+        if !contigs.contains(id.as_str()) {
+            write_contig(writer, id, contig)?;
+        }
+    }
+
+    for (key, collection) in header.other_records() {
+        if !others.contains(key) {
+            write_other(writer, file_format, key, collection)?;
+        }
+    }
 
     Ok(())
 }
@@ -107,9 +228,70 @@ mod tests {
             .set_file_format(FileFormat::new(4, 5))
             .build();
 
-        write_header(&mut buf, &header)?;
+        write_header(&mut buf, &header, RecordOrder::default())?;
 
         let expected = b"##fileformat=VCFv4.5
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+";
+
+        assert_eq!(buf, expected);
+
+        Ok(())
+    }
+
+    const INTERLEAVED_HEADER: &str = "##fileformat=VCFv4.5
+##FILTER=<ID=q10,Description=\"Quality below 10\">
+##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of samples\">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+";
+
+    #[test]
+    fn test_write_header_with_record_order_as_added() -> io::Result<()> {
+        let header: Header = INTERLEAVED_HEADER.parse().map_err(io::Error::other)?;
+
+        let mut buf = Vec::new();
+        write_header(&mut buf, &header, RecordOrder::AsAdded)?;
+
+        assert_eq!(buf, INTERLEAVED_HEADER.as_bytes());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_header_with_record_order_grouped() -> io::Result<()> {
+        let header: Header = INTERLEAVED_HEADER.parse().map_err(io::Error::other)?;
+
+        let mut buf = Vec::new();
+        write_header(&mut buf, &header, RecordOrder::Grouped)?;
+
+        let expected = b"##fileformat=VCFv4.5
+##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of samples\">
+##FILTER=<ID=q10,Description=\"Quality below 10\">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+";
+
+        assert_eq!(buf, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_header_with_record_order_as_added_and_untracked_records() -> io::Result<()> {
+        use crate::header::record::value::{Map, map::Filter};
+
+        let mut header: Header = INTERLEAVED_HEADER.parse().map_err(io::Error::other)?;
+
+        header
+            .filters_mut()
+            .insert(String::from("q20"), Map::<Filter>::new("Quality below 20"));
+
+        let mut buf = Vec::new();
+        write_header(&mut buf, &header, RecordOrder::AsAdded)?;
+
+        let expected = b"##fileformat=VCFv4.5
+##FILTER=<ID=q10,Description=\"Quality below 10\">
+##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of samples\">
+##FILTER=<ID=q20,Description=\"Quality below 20\">
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
 ";
 

--- a/noodles-vcf/src/io/writer/record_order.rs
+++ b/noodles-vcf/src/io/writer/record_order.rs
@@ -1,0 +1,15 @@
+/// The order in which VCF header records are written.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RecordOrder {
+    /// Records are grouped by category.
+    ///
+    /// Categories are written as `INFO`, `FILTER`, `FORMAT`, `ALT`, `contig`, and, finally,
+    /// nonstandard records. Within a category, records keep the order they were added in.
+    #[default]
+    Grouped,
+    /// Records are written in the order they were added to the header.
+    ///
+    /// This uses [`crate::Header::record_order`]. Records missing from it, e.g., those added using
+    /// [`crate::Header::infos_mut`], are written last, grouped by category.
+    AsAdded,
+}


### PR DESCRIPTION
Closes #413.

`io::writer::header::write_header` writes records grouped by category: `INFO`, then `FILTER`, `FORMAT`, `ALT`, `contig`, and finally other records. `Header` keeps insertion order *within* a category, because each category is an `IndexMap`, but nothing relates the categories to each other. Reading a VCF header and writing it back therefore does not reproduce the input, even when nothing was modified.

This adds `Header::record_order`, the record keys in the order they were added, populated by the builder and the parser, and `io::writer::Builder::set_record_order`, which selects between:

- `RecordOrder::Grouped`, the current behavior and the default, so nothing changes for existing users;
- `RecordOrder::AsAdded`, which follows `Header::record_order` and makes the round trip idempotent.

Records added through the mutable accessors, e.g., `Header::infos_mut`, are not tracked. They are written last, grouped by category, so a header mutated that way still writes every record exactly once and no key is lost. A key that no longer resolves to a record is skipped.

Two things worth flagging before you find them:

1. `Header::PartialEq` is now implemented manually and ignores the record order. Without that, two headers holding the same records compare unequal because they were built in a different order, which would break existing callers and several tests in this repository.
2. This is only a behavior change if `AsAdded` is selected. `Writer::new` and `Builder::default` both keep `Grouped`.

Split into three commits: the header change, the writer change, the changelog. Each builds and passes `cargo fmt -- --check`, `cargo clippy --all-features -- --deny warnings`, and `cargo test --all-features` across the whole workspace on its own.

Three tests cover it: the round trip under `AsAdded`, the unchanged grouped output, and the fallback for records added through a mutable accessor.

I opened #413 first rather than sending this straight over, and I am still happy to drop it, change its shape, or let you write it your own way.

Context, not justification: noticed while using noodles-vcf as an independent reader to cross-check a VCF writer in <https://github.com/IPNP-BIPN/htsjdk-rs>. The defect stands on its own regardless of that; I mention it only so you know where it came from.
