### PR TITLE
cram: Add access to the raw blocks of a container slice

### DIFF
--- a/noodles-cram/CHANGELOG.md
+++ b/noodles-cram/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Added
+
+  * cram/container: Add block module (`container::block`).
+
+    This exposes `block::CompressionMethod`, `block::ContentType`, and
+    `block::ContentId`, which were already written as public items.
+
+  * cram/io/reader/container/slice: Add raw blocks iterator
+    (`Slice::blocks`).
+
+    Unlike `Slice::decode_blocks`, this decodes nothing and does not require
+    the block content types to be what the specification expects, which makes
+    it usable to inspect or validate a container.
+
+  * cram/io/reader: Add container block (`io::reader::Block`).
+
 ### Changed
 
   * cram: Update to lzma-rust2 0.20.0.

--- a/noodles-cram/src/container.rs
+++ b/noodles-cram/src/container.rs
@@ -1,6 +1,6 @@
 //! CRAM container and fields.
 
-pub(crate) mod block;
+pub mod block;
 pub mod block_content_encoder_map;
 pub mod compression_header;
 mod header;

--- a/noodles-cram/src/container/block.rs
+++ b/noodles-cram/src/container/block.rs
@@ -1,6 +1,11 @@
+//! CRAM container block and fields.
+
 mod compression_method;
 mod content_type;
 
 pub use self::{compression_method::CompressionMethod, content_type::ContentType};
 
+/// A CRAM container block content ID.
+///
+/// This associates an external data block with a data series.
 pub type ContentId = i32;

--- a/noodles-cram/src/io/reader.rs
+++ b/noodles-cram/src/io/reader.rs
@@ -14,7 +14,12 @@ use noodles_core::Region;
 use noodles_fasta as fasta;
 use noodles_sam as sam;
 
-pub use self::{builder::Builder, container::Container, query::Query, records::Records};
+pub use self::{
+    builder::Builder,
+    container::{Block, Container},
+    query::Query,
+    records::Records,
+};
 use self::{container::read_container, header::read_header};
 use crate::{FileDefinition, crai};
 

--- a/noodles-cram/src/io/reader/container.rs
+++ b/noodles-cram/src/io/reader/container.rs
@@ -8,8 +8,10 @@ use std::{
     iter,
 };
 
+pub use self::{
+    block::Block, compression_header::read_compression_header, slice::Slice, slice::read_slice,
+};
 use self::{block::read_block_as, header::read_header};
-pub use self::{compression_header::read_compression_header, slice::Slice, slice::read_slice};
 use crate::container::{CompressionHeader, Header};
 
 /// A CRAM container.

--- a/noodles-cram/src/io/reader/container/block.rs
+++ b/noodles-cram/src/io/reader/container/block.rs
@@ -11,16 +11,50 @@ use crate::{
     io::reader::num::{read_itf8, read_itf8_as, read_u32_le},
 };
 
+/// A raw CRAM container block.
+///
+/// This is a block as it appears in the stream. Its CRC32 has been verified, but its data is
+/// still encoded: use [`Self::decode`] to decompress it.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Block<'c> {
+    /// The method used to compress the data.
     pub compression_method: CompressionMethod,
+    /// What the block holds.
     pub content_type: ContentType,
+    /// The block content ID.
+    ///
+    /// This associates an external data block with a data series.
     pub content_id: ContentId,
+    /// The size of the data after decoding, in bytes.
     pub uncompressed_size: usize,
+    /// The compressed data.
     pub src: &'c [u8],
 }
 
 impl<'c> Block<'c> {
+    /// Decodes the block data.
+    ///
+    /// Data compressed with [`CompressionMethod::None`] is borrowed rather than copied.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noodles_cram::{
+    ///     container::block::{CompressionMethod, ContentType},
+    ///     io::reader::Block,
+    /// };
+    ///
+    /// let block = Block {
+    ///     compression_method: CompressionMethod::None,
+    ///     content_type: ContentType::ExternalData,
+    ///     content_id: 1,
+    ///     uncompressed_size: 4,
+    ///     src: b"ndls",
+    /// };
+    ///
+    /// assert_eq!(*block.decode()?, b"ndls"[..]);
+    /// # Ok::<_, std::io::Error>(())
+    /// ```
     pub fn decode(&self) -> io::Result<Cow<'c, [u8]>> {
         use crate::codecs::{aac, bzip2, fqzcomp, gzip, lzma, name_tokenizer, rans_4x8, rans_nx16};
 
@@ -54,7 +88,7 @@ impl<'c> Block<'c> {
     }
 }
 
-fn read_block<'c>(src: &mut &'c [u8]) -> io::Result<Block<'c>> {
+pub(crate) fn read_block<'c>(src: &mut &'c [u8]) -> io::Result<Block<'c>> {
     let original_src = *src;
 
     let mut compression_method = read_compression_method(src)?;
@@ -98,7 +132,10 @@ fn read_block<'c>(src: &mut &'c [u8]) -> io::Result<Block<'c>> {
     })
 }
 
-pub fn read_block_as<'c>(src: &mut &'c [u8], content_type: ContentType) -> io::Result<Block<'c>> {
+pub(crate) fn read_block_as<'c>(
+    src: &mut &'c [u8],
+    content_type: ContentType,
+) -> io::Result<Block<'c>> {
     let block = read_block(src)?;
     validate_content_type(block.content_type, content_type)?;
     Ok(block)

--- a/noodles-cram/src/io/reader/container/slice.rs
+++ b/noodles-cram/src/io/reader/container/slice.rs
@@ -1,7 +1,7 @@
 mod header;
 pub mod records;
 
-use std::{borrow::Cow, io, sync::Arc};
+use std::{borrow::Cow, io, iter, sync::Arc};
 
 use noodles_core::Position;
 use noodles_fasta as fasta;
@@ -11,7 +11,10 @@ use self::{
     header::read_header,
     records::{ExternalDataReaders, Records},
 };
-use super::read_block_as;
+use super::{
+    block::{Block, read_block},
+    read_block_as,
+};
 use crate::{
     Record, calculate_normalized_sequence_digest,
     container::{
@@ -35,6 +38,54 @@ pub struct Slice<'c> {
 impl<'c> Slice<'c> {
     pub(crate) fn header(&self) -> &Header {
         &self.header
+    }
+
+    /// Returns an iterator over the raw blocks in this slice.
+    ///
+    /// This is the core data block followed by the external data blocks, as they appear in the
+    /// stream. Each block carries its compression method, content type, content ID, uncompressed
+    /// size, and compressed source, and can be decoded using [`Block::decode`].
+    ///
+    /// Unlike [`Self::decode_blocks`], this does not decode anything and does not require the
+    /// content types to be what the specification expects, which is what makes it usable to
+    /// inspect or validate a container.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use std::{fs::File, io};
+    /// use noodles_cram::{self as cram, io::reader::Container};
+    ///
+    /// let mut reader = File::open("sample.cram").map(cram::io::Reader::new)?;
+    /// reader.read_header()?;
+    ///
+    /// let mut container = Container::default();
+    ///
+    /// while reader.read_container(&mut container)? != 0 {
+    ///     for result in container.slices() {
+    ///         let slice = result?;
+    ///
+    ///         for result in slice.blocks() {
+    ///             let block = result?;
+    ///             println!("{:?} {}", block.content_type, block.uncompressed_size);
+    ///         }
+    ///     }
+    /// }
+    /// # Ok::<_, io::Error>(())
+    /// ```
+    pub fn blocks(&self) -> impl Iterator<Item = io::Result<Block<'c>>> + use<'c, '_> {
+        let block_count = self.header.block_count();
+        let mut src = self.src;
+        let mut i = 0;
+
+        iter::from_fn(move || {
+            if i < block_count {
+                i += 1;
+                Some(read_block(&mut src))
+            } else {
+                None
+            }
+        })
     }
 
     #[allow(clippy::type_complexity)]
@@ -423,6 +474,55 @@ mod tests {
 
     use super::*;
     use crate::record::Flags;
+
+    #[test]
+    fn test_blocks() -> io::Result<()> {
+        use crate::container::{
+            ReferenceSequenceContext,
+            block::{CompressionMethod, ContentType},
+        };
+
+        // An external data block with a content ID of 1 and the data b"ndls".
+        const SRC: [u8; 13] = [
+            0x00, // compression method = none (0)
+            0x04, // content type = external data (4)
+            0x01, // block content ID = 1
+            0x04, // size in bytes = 4
+            0x04, // raw size in bytes = 4
+            0x6e, 0x64, 0x6c, 0x73, // data = b"ndls"
+            0xd7, 0x12, 0x46, 0x3e, // CRC32 = 3e4612d7
+        ];
+
+        let header = Header {
+            reference_sequence_context: ReferenceSequenceContext::None,
+            record_count: 0,
+            record_counter: 0,
+            block_count: 1,
+            block_content_ids: vec![1],
+            embedded_reference_bases_block_content_id: None,
+            reference_md5: None,
+            optional_tags: Vec::new(),
+        };
+
+        let slice = Slice {
+            header,
+            src: &SRC[..],
+        };
+
+        let blocks: Vec<_> = slice.blocks().collect::<io::Result<_>>()?;
+
+        assert_eq!(blocks.len(), 1);
+
+        let block = &blocks[0];
+        assert_eq!(block.compression_method, CompressionMethod::None);
+        assert_eq!(block.content_type, ContentType::ExternalData);
+        assert_eq!(block.content_id, 1);
+        assert_eq!(block.uncompressed_size, 4);
+        assert_eq!(block.src, b"ndls");
+        assert_eq!(*block.decode()?, b"ndls"[..]);
+
+        Ok(())
+    }
 
     #[test]
     fn test_resolve_mates() -> io::Result<()> {


### PR DESCRIPTION
`Slice::decode_blocks` is currently the only way to reach the blocks of a slice. It decodes every block eagerly and calls `read_block_as`, which rejects any block whose content type is not the one the specification expects. That is the right behavior for reading records, but it means a container whose blocks are wrong cannot be inspected at all: the thing you want to look at is the thing that makes the call fail.

`Slice::blocks` returns the blocks as they appear in the stream, with their compression method, content type, content ID, uncompressed size, and compressed source. Nothing is decoded, `Block::decode` does that on demand, and the block CRC32 is still verified while reading.

Getting there needs two visibility changes, both of the same kind as #411 and #412:

- `container::block` is `pub(crate)`, but `CompressionMethod` and `ContentType` inside it are already `pub`, fully documented, and marked `#[non_exhaustive]`. They read as items written to be public and then hidden by the module declaration. Both are defined by the CRAM specification in § 8 "Block structure".
- `Block` is re-exported as `io::reader::Block`, next to `Container`. Without it the type is returned by a public method but cannot be named, and `rustc` flags the re-export inside `io::reader::container` as unused because that module is itself `pub(crate)`.

While doing this I noticed a related gap I deliberately left alone: `Slice` is returned by `Container::slices` and has the same problem, reachable through method calls but impossible to name. Happy to fix that too, in a separate change, if you agree it is one.

`read_block` and `read_block_as` are now both `pub(crate)`; neither was reachable before, so no public signature changes.

Split into three commits: the container change, the reader change, the changelog. Each builds and passes `cargo fmt -- --check`, `cargo clippy --all-features -- --deny warnings`, and `cargo test --all-features` across the whole workspace on its own.

Note on overlap: the changelog entry adds an `## Unreleased` section, as do #411 and #412. Whichever lands first, I will rebase the others.
