### PR TITLE
bgzf: Gate the multithreaded reader and writer behind a feature

### DIFF
--- a/noodles-bgzf/CHANGELOG.md
+++ b/noodles-bgzf/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+  * bgzf: Add `multithreaded` feature.
+
+    This gates the multithreaded reader (`io::MultithreadedReader`) and writer
+    (`io::MultithreadedWriter`). It is enabled by default, so the previous
+    behavior is unchanged. Disabling it removes the crossbeam-channel and rayon
+    dependencies.
+
 ## 0.51.0 - 2026-08-03
 
 ### Fixed

--- a/noodles-bgzf/Cargo.toml
+++ b/noodles-bgzf/Cargo.toml
@@ -12,12 +12,13 @@ documentation = "https://docs.rs/noodles-bgzf"
 categories = ["compression"]
 
 [features]
+default = ["multithreaded"]
 async = ["dep:futures", "dep:pin-project-lite", "dep:tokio", "dep:tokio-util"]
 libdeflate = ["dep:libdeflater"]
+multithreaded = ["dep:crossbeam-channel", "dep:rayon"]
 
 [dependencies]
 bytes.workspace = true
-crossbeam-channel = "0.5.6"
 zlib-rs = { version = "0.6.3", features = ["avx512"] }
 
 futures = { workspace = true, optional = true, features = ["std"] }
@@ -26,7 +27,9 @@ tokio = { workspace = true, optional = true, features = ["fs", "io-util", "rt"] 
 tokio-util = { version = "0.7.0", optional = true, features = ["codec"] }
 
 libdeflater = { workspace = true, optional = true }
-rayon = "1.12.0"
+
+crossbeam-channel = { version = "0.5.6", optional = true }
+rayon = { version = "1.12.0", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["io-std", "macros", "rt-multi-thread"] }
@@ -42,5 +45,13 @@ name = "bgzf_read_async"
 required-features = ["async"]
 
 [[example]]
+name = "bgzf_read_multithreaded"
+required-features = ["multithreaded"]
+
+[[example]]
 name = "bgzf_write_async"
 required-features = ["async"]
+
+[[example]]
+name = "bgzf_write_multithreaded"
+required-features = ["multithreaded"]

--- a/noodles-bgzf/src/io.rs
+++ b/noodles-bgzf/src/io.rs
@@ -3,7 +3,9 @@
 mod block;
 mod buf_read;
 pub mod indexed_reader;
+#[cfg(feature = "multithreaded")]
 mod multithreaded_reader;
+#[cfg(feature = "multithreaded")]
 pub mod multithreaded_writer;
 mod read;
 pub mod reader;
@@ -12,9 +14,12 @@ pub mod writer;
 
 pub(crate) use self::block::Block;
 pub use self::{
-    buf_read::BufRead, indexed_reader::IndexedReader, multithreaded_reader::MultithreadedReader,
-    multithreaded_writer::MultithreadedWriter, read::Read, reader::Reader, seek::Seek,
+    buf_read::BufRead, indexed_reader::IndexedReader, read::Read, reader::Reader, seek::Seek,
     writer::Writer,
+};
+#[cfg(feature = "multithreaded")]
+pub use self::{
+    multithreaded_reader::MultithreadedReader, multithreaded_writer::MultithreadedWriter,
 };
 
 #[cfg(test)]
@@ -86,6 +91,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "multithreaded")]
     #[test]
     fn test_self_multithreaded() -> io::Result<()> {
         let mut writer = MultithreadedWriter::new(Vec::new());


### PR DESCRIPTION
`crossbeam-channel` and `rayon` are mandatory dependencies of `noodles-bgzf`, but `grep` finds them in exactly three files: `io/multithreaded_reader.rs`, `io/multithreaded_writer.rs`, and `io/multithreaded_writer/builder.rs`. Nothing else in the crate uses them, and nothing else in the workspace uses `MultithreadedReader` or `MultithreadedWriter` either; the only reference outside those files is a doctest in `noodles-bam`.

Because every BGZF-backed format depends on this crate, that cost is paid by every consumer of noodles-bam, -bcf, -cram, -csi, -tabix and -vcf, including those that only ever read a single-threaded stream, or an index, and never start a thread pool.

This adds a `multithreaded` feature, **enabled by default**, gating the two types and the two dependencies. Nothing changes for anyone who does not opt out. With `--no-default-features`, seven crates leave the graph:

```
crossbeam-channel v0.5.16
crossbeam-deque v0.8.7
crossbeam-epoch v0.9.20
crossbeam-utils v0.8.22
either v1.17.0
rayon v1.12.0
rayon-core v1.13.0
```

The two multithreaded examples now declare `required-features`, in the same way as the asynchronous ones already do.

Verified in three configurations: `--no-default-features` (31 unit, 49 doc), default (33 unit, 61 doc), and `--all-features` across the whole workspace, plus `cargo fmt -- --check` and `cargo clippy --all-features -- --deny warnings`. Both commits pass all of it on their own.

One thing this deliberately does not do. The feature stops at this crate, so a consumer reaching BGZF through `noodles-bam` still gets rayon, because `noodles-bam` depends on `noodles-bgzf` with default features. Forwarding the feature through the crates that depend on this one is the natural follow-up, but it touches seven manifests and the shape of that is yours to choose, so I would rather hear whether you want it than send it unasked.

Also worth saying plainly: I have a use for the smaller graph, and that is not the argument. The argument is that a mandatory dependency for an optional capability is a cost with no opt-out, which holds whether or not anyone takes it.
