### PR TITLE
bam: Make the BAI reader and writer usable without noodles-sam

### DIFF
--- a/noodles-bam/CHANGELOG.md
+++ b/noodles-bam/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+  * bam: Add `records` feature.
+
+    This gates the record (`record`), I/O (`io`), and filesystem operations
+    (`fs`) modules, i.e., everything but the index (`bai`). It is enabled by
+    default, so the previous behavior is unchanged. Disabling it removes the
+    noodles-sam dependency, which the index does not use.
+
+### Changed
+
+  * bam/bai: Read and write integers using the index's own helpers.
+
+    The index previously borrowed `io::reader::num` and `io::writer::num`,
+    which belong to the record reader and writer.
+
 ## 0.95.0 - 2026-08-21
 
 ### Changed

--- a/noodles-bam/Cargo.toml
+++ b/noodles-bam/Cargo.toml
@@ -12,13 +12,16 @@ documentation = "https://docs.rs/noodles-bam"
 categories = ["parser-implementations", "science::bioinformatics"]
 
 [features]
+default = ["records"]
 async = [
   "dep:futures",
   "dep:pin-project-lite",
   "dep:tokio",
   "noodles-bgzf/async",
   "noodles-csi/async",
+  "records",
 ]
+records = ["dep:noodles-sam"]
 
 [dependencies]
 bstr.workspace = true
@@ -31,7 +34,7 @@ tokio = { workspace = true, optional = true, features = ["fs", "io-util"] }
 noodles-bgzf = { path = "../noodles-bgzf", version = "0.51.0" }
 noodles-core = { path = "../noodles-core", version = "0.20.0" }
 noodles-csi = { path = "../noodles-csi", version = "0.61.0" }
-noodles-sam = { path = "../noodles-sam", version = "0.90.0" }
+noodles-sam = { path = "../noodles-sam", version = "0.90.0", optional = true }
 
 [dev-dependencies]
 noodles-sam = { path = "../noodles-sam", version = "0.90.0", features = ["async"] }

--- a/noodles-bam/src/bai/io.rs
+++ b/noodles-bam/src/bai/io.rs
@@ -1,5 +1,6 @@
 //! BAI I/O.
 
+mod num;
 mod reader;
 mod writer;
 

--- a/noodles-bam/src/bai/io/num.rs
+++ b/noodles-bam/src/bai/io/num.rs
@@ -1,0 +1,38 @@
+use std::{
+    io::{self, Read, Write},
+    mem,
+};
+
+pub(crate) fn read_u32_le<R>(reader: &mut R) -> io::Result<u32>
+where
+    R: Read,
+{
+    let mut buf = [0; mem::size_of::<u32>()];
+    reader.read_exact(&mut buf)?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+pub(crate) fn read_u64_le<R>(reader: &mut R) -> io::Result<u64>
+where
+    R: Read,
+{
+    let mut buf = [0; mem::size_of::<u64>()];
+    reader.read_exact(&mut buf)?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+pub(crate) fn write_u32_le<W>(writer: &mut W, n: u32) -> io::Result<()>
+where
+    W: Write,
+{
+    let buf = n.to_le_bytes();
+    writer.write_all(&buf)
+}
+
+pub(crate) fn write_u64_le<W>(writer: &mut W, n: u64) -> io::Result<()>
+where
+    W: Write,
+{
+    let buf = n.to_le_bytes();
+    writer.write_all(&buf)
+}

--- a/noodles-bam/src/bai/io/reader/index.rs
+++ b/noodles-bam/src/bai/io/reader/index.rs
@@ -4,7 +4,7 @@ mod reference_sequences;
 use std::io::{self, Read};
 
 use self::{magic_number::read_magic_number, reference_sequences::read_reference_sequences};
-use crate::{bai::Index, io::reader::num::read_u64_le};
+use crate::bai::{Index, io::num::read_u64_le};
 
 pub(super) fn read_index<R>(reader: &mut R) -> io::Result<Index>
 where

--- a/noodles-bam/src/bai/io/reader/index/reference_sequences.rs
+++ b/noodles-bam/src/bai/io/reader/index/reference_sequences.rs
@@ -8,7 +8,7 @@ use noodles_csi::binning_index::index::{
 };
 
 use self::{bins::read_bins, intervals::read_intervals};
-use crate::io::reader::num::read_u32_le;
+use crate::bai::io::num::read_u32_le;
 
 pub(super) fn read_reference_sequences<R>(
     reader: &mut R,

--- a/noodles-bam/src/bai/io/reader/index/reference_sequences/bins.rs
+++ b/noodles-bam/src/bai/io/reader/index/reference_sequences/bins.rs
@@ -3,7 +3,7 @@ use std::io::{self, Read};
 use indexmap::IndexMap;
 use noodles_csi::binning_index::index::reference_sequence::{Bin, Metadata};
 
-use crate::io::reader::num::read_u32_le;
+use crate::bai::io::num::read_u32_le;
 
 pub(super) fn read_bins<R>(reader: &mut R) -> io::Result<(IndexMap<usize, Bin>, Option<Metadata>)>
 where

--- a/noodles-bam/src/bai/io/reader/index/reference_sequences/intervals.rs
+++ b/noodles-bam/src/bai/io/reader/index/reference_sequences/intervals.rs
@@ -2,7 +2,7 @@ use std::io::{self, Read};
 
 use noodles_bgzf as bgzf;
 
-use crate::io::reader::num::{read_u32_le, read_u64_le};
+use crate::bai::io::num::{read_u32_le, read_u64_le};
 
 pub(super) fn read_intervals<R>(reader: &mut R) -> io::Result<Vec<bgzf::VirtualPosition>>
 where

--- a/noodles-bam/src/bai/io/writer/index.rs
+++ b/noodles-bam/src/bai/io/writer/index.rs
@@ -6,7 +6,7 @@ use std::io::{self, Write};
 use noodles_csi::BinningIndex;
 
 use self::{magic_number::write_magic_number, reference_sequences::write_reference_sequences};
-use crate::{bai::Index, io::writer::num::write_u64_le};
+use crate::bai::{Index, io::num::write_u64_le};
 
 pub(super) fn write_index<W>(writer: &mut W, index: &Index) -> io::Result<()>
 where
@@ -41,7 +41,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::{bai::MAGIC_NUMBER, io::writer::num::write_u32_le};
+    use crate::bai::{MAGIC_NUMBER, io::num::write_u32_le};
 
     #[test]
     fn test_write_index() -> io::Result<()> {

--- a/noodles-bam/src/bai/io/writer/index/reference_sequences.rs
+++ b/noodles-bam/src/bai/io/writer/index/reference_sequences.rs
@@ -10,7 +10,7 @@ use noodles_csi::binning_index::{
 };
 
 use self::{bins::write_bins, intervals::write_intervals, metadata::write_metadata};
-use crate::io::writer::num::write_u32_le;
+use crate::bai::io::num::write_u32_le;
 
 pub(super) fn write_reference_sequences<W>(
     writer: &mut W,

--- a/noodles-bam/src/bai/io/writer/index/reference_sequences/bins.rs
+++ b/noodles-bam/src/bai/io/writer/index/reference_sequences/bins.rs
@@ -7,7 +7,7 @@ use noodles_csi::binning_index::index::reference_sequence::{Bin, Metadata};
 
 use self::chunks::write_chunks;
 use super::write_metadata;
-use crate::io::writer::num::write_u32_le;
+use crate::bai::io::num::write_u32_le;
 
 pub(super) fn write_bins<W>(
     writer: &mut W,

--- a/noodles-bam/src/bai/io/writer/index/reference_sequences/bins/chunks.rs
+++ b/noodles-bam/src/bai/io/writer/index/reference_sequences/bins/chunks.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 
 use noodles_csi::binning_index::index::reference_sequence::bin::Chunk;
 
-use crate::io::writer::num::{write_u32_le, write_u64_le};
+use crate::bai::io::num::{write_u32_le, write_u64_le};
 
 pub(super) fn write_chunks<W>(writer: &mut W, chunks: &[Chunk]) -> io::Result<()>
 where

--- a/noodles-bam/src/bai/io/writer/index/reference_sequences/intervals.rs
+++ b/noodles-bam/src/bai/io/writer/index/reference_sequences/intervals.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 
 use noodles_bgzf as bgzf;
 
-use crate::io::writer::num::{write_u32_le, write_u64_le};
+use crate::bai::io::num::{write_u32_le, write_u64_le};
 
 pub(super) fn write_intervals<W>(
     writer: &mut W,

--- a/noodles-bam/src/bai/io/writer/index/reference_sequences/metadata.rs
+++ b/noodles-bam/src/bai/io/writer/index/reference_sequences/metadata.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 
 use noodles_csi::binning_index::index::reference_sequence::{Bin, Metadata};
 
-use crate::io::writer::num::{write_u32_le, write_u64_le};
+use crate::bai::io::num::{write_u32_le, write_u64_le};
 
 pub(super) fn write_metadata<W>(writer: &mut W, metadata: &Metadata) -> io::Result<()>
 where

--- a/noodles-bam/src/io/reader/num.rs
+++ b/noodles-bam/src/io/reader/num.rs
@@ -11,12 +11,3 @@ where
     reader.read_exact(&mut buf)?;
     Ok(u32::from_le_bytes(buf))
 }
-
-pub(crate) fn read_u64_le<R>(reader: &mut R) -> io::Result<u64>
-where
-    R: Read,
-{
-    let mut buf = [0; mem::size_of::<u64>()];
-    reader.read_exact(&mut buf)?;
-    Ok(u64::from_le_bytes(buf))
-}

--- a/noodles-bam/src/io/writer/num.rs
+++ b/noodles-bam/src/io/writer/num.rs
@@ -15,11 +15,3 @@ where
     let buf = n.to_le_bytes();
     writer.write_all(&buf)
 }
-
-pub(crate) fn write_u64_le<W>(writer: &mut W, n: u64) -> io::Result<()>
-where
-    W: Write,
-{
-    let buf = n.to_le_bytes();
-    writer.write_all(&buf)
-}

--- a/noodles-bam/src/lib.rs
+++ b/noodles-bam/src/lib.rs
@@ -8,7 +8,9 @@
 //! ## Read all records
 //!
 //! ```no_run
-//! # use std::{fs::File, io};
+//! # #[cfg(feature = "records")]
+//! # fn main() -> std::io::Result<()> {
+//! # use std::fs::File;
 //! use noodles_bam as bam;
 //!
 //! let mut reader = File::open("sample.bam").map(bam::io::Reader::new)?;
@@ -18,7 +20,10 @@
 //!     let record = result?;
 //!     // ...
 //! }
-//! # Ok::<_, io::Error>(())
+//! # Ok(())
+//! # }
+//! # #[cfg(not(feature = "records"))]
+//! # fn main() {}
 //! ```
 //!
 //! ## Query records
@@ -26,7 +31,8 @@
 //! Querying allows filtering records by region. It requires an associated BAM index (BAI).
 //!
 //! ```no_run
-//! # use std::fs::File;
+//! # #[cfg(feature = "records")]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use noodles_bam as bam;
 //!
 //! let mut reader = bam::io::indexed_reader::Builder::default().build_from_path("sample.bam")?;
@@ -39,16 +45,24 @@
 //!     let record = result?;
 //!     // ...
 //! }
-//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! # Ok(())
+//! # }
+//! # #[cfg(not(feature = "records"))]
+//! # fn main() {}
 //! ```
 
 #[cfg(feature = "async")]
 pub mod r#async;
 
 pub mod bai;
+#[cfg(feature = "records")]
 pub mod fs;
+#[cfg(feature = "records")]
 pub mod io;
+#[cfg(feature = "records")]
 pub mod record;
+#[cfg(feature = "records")]
 mod record_ref;
 
+#[cfg(feature = "records")]
 pub use self::{record::Record, record_ref::RecordRef};


### PR DESCRIPTION
Closes #417, taking the first of the three options in it.

Two commits of substance, and the first stands on its own regardless of what you think of the second.

**`bam/bai`: decouple the index from the record reader and writer.** The index read its integers with `io::reader::num` and wrote them with `io::writer::num`, which are private helpers of the record reader and writer. That is the wrong direction: BAI is defined independently of records, and the index knows nothing about them. It now has its own `bai::io::num`. The proof that these were the index's helpers all along is that `read_u64_le` and `write_u64_le` become dead code once it stops calling them, so they are removed.

**`bam`: gate everything but the index behind a `records` feature.** Enabled by default, so nothing changes unless it is turned off. It gates `record`, `io`, and `fs`; `bai` is always available. `async` implies `records`, since the asynchronous modules read and write records.

The normal dependency graph, measured with `cargo tree -e normal`:

| | crates |
|---|---|
| default | 27 |
| `--no-default-features` | 19 |

The eight that leave are `noodles-sam`, `bitflags`, and the six `lexical-*` crates, which exist for SAM text parsing.

## What it costs you, which #417 said I could not judge from outside

Now that it is built, I can. The tax is not the four `#[cfg]` lines in `lib.rs`; it is the periphery:

- 16 `[[example]]` blocks gained a `required-features`, mirroring what the asynchronous examples already do. That is 48 lines of manifest.
- The two crate-level doctests needed an explicit `fn main` under `#[cfg]`, because a doc example cannot otherwise be conditional. The added lines are all `#`-prefixed, so nothing changes in the rendered documentation, but they are there in the source.
- Four small helpers now exist in two places. A shared crate-root `num` would avoid that, but moving it touches 54 call sites across 45 files of unrelated modules, which is a worse diff than the duplication.

If you would rather have option 2 from the issue, the index in its own crate next to `noodles-csi` and `noodles-tabix`, this PR is the wrong shape and I will close it without argument. If you would rather have option 3, leave it as it is, the first commit is still worth taking on its own and I will reduce the PR to that.

Verified in four configurations: `--no-default-features` (7 unit, 17 doc), default (133, 64), `--all-features` (154, 102), and the whole workspace at `--all-features`, plus `cargo fmt -- --check` and `cargo clippy --deny warnings` both with and without default features. All three commits pass all of it on their own.
