### PR TITLE
sam/record: Borrow quality scores when encoding an alignment record

### DIFF
--- a/noodles-sam/CHANGELOG.md
+++ b/noodles-sam/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+  * sam/record: Borrow quality scores when encoding an alignment record.
+
+    `Record` did not override `alignment::record::Record::quality_scores_ref`,
+    so it fell back to the boxed default, costing an allocation and a dynamic
+    dispatch per base. It now returns `QualityScoresRef::Offset`, which is the
+    variant that describes SAM quality scores.
+
 ## 0.89.0 - 2026-08-03
 
 ### Changed

--- a/noodles-sam/src/record.rs
+++ b/noodles-sam/src/record.rs
@@ -319,7 +319,46 @@ impl crate::alignment::Record for Record {
         Box::new(self.quality_scores())
     }
 
+    fn quality_scores_ref(&self) -> crate::alignment::record::QualityScoresRef<'_> {
+        const OFFSET: u8 = b'!';
+        crate::alignment::record::QualityScoresRef::Offset(self.0.quality_scores(), OFFSET)
+    }
+
     fn data(&self) -> Box<dyn crate::alignment::record::Data<'_> + '_> {
         Box::new(self.data())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::alignment::record::{QualityScoresRef, Record as _};
+
+    use super::*;
+
+    #[test]
+    fn test_quality_scores_ref() -> Result<(), Box<dyn std::error::Error>> {
+        let src = b"r0\t4\t*\t0\t255\t*\t*\t0\t0\tACGT\tNDLS";
+        let record = Record::try_from(&src[..])?;
+
+        assert!(matches!(
+            record.quality_scores_ref(),
+            QualityScoresRef::Offset(s, b'!') if s == b"NDLS"
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_quality_scores_ref_with_missing_quality_scores()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let src = b"r0\t4\t*\t0\t255\t*\t*\t0\t0\tACGT\t*";
+        let record = Record::try_from(&src[..])?;
+
+        assert!(matches!(
+            record.quality_scores_ref(),
+            QualityScoresRef::Offset(s, _) if s.is_empty()
+        ));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
`sam::Record` overrides `alignment::record::Record::sequence_ref`, but not `quality_scores_ref`, `cigar_ref` or `data_ref`. `bam::Record` overrides all four. So quality scores fall through to the default:

```rust
fn quality_scores_ref(&self) -> QualityScoresRef<'_> {
    QualityScoresRef::QualityScores(self.quality_scores())
}
```

which boxes an iterator per record and then dispatches dynamically per base. `QualityScoresRef::Offset(&[u8], u8)` exists and describes exactly what a SAM record holds, Phred+33 bytes, but nothing produced it, so `write_offset_quality_scores` in the BAM encoder was dead for this path. This makes `sam::Record` return it.

`Fields::quality_scores` already normalizes `*` to an empty slice, so a missing QUAL still takes the missing-scores branch and is written as 0xff.

## Measurement

Apple M4 Max, 12 performance and 4 efficiency cores, 128 GB, macOS, rustc 1.97.1, release with `lto = "fat"` and `codegen-units = 1`, `noodles-bgzf/libdeflate` enabled. Input is `NexPond-377866.NA12878.WEX.20.21.with.unmapped.bam` converted to SAM: 1,604,108 records, 85 reference sequences, 620 MB of text. Best of three runs, page cache warm.

| stage | before | after |
|---|---|---|
| parse records only, no writer | 0.229 s | 0.229 s |
| parse + encode, writing to `io::sink()` | 1.216 s | 1.011 s |
| **encode alone, by subtraction** | **0.985 s** | **0.782 s** |
| full SAM -> BAM, 1 BGZF worker | 3.63 s | 3.60 s |
| full SAM -> BAM, 2 workers | 1.89 s | 1.89 s |
| full SAM -> BAM, 4 workers | 1.32 s | 1.09 s |
| full SAM -> BAM, 8 workers | 1.33 s | 1.08 s |
| full SAM -> BAM, 16 workers | 1.33 s | 1.09 s |

At one and two workers compression is still the critical path, so nothing moves there. From four workers on, where the serial producer is the wall, the conversion is 18% faster.

## Correctness

- The output file is byte-identical to what noodles produced before this change, `cmp` on the whole BAM.
- Records are identical to htslib's for the same input, comparing `samtools view` output.
- The header is identical to htslib's, comparing `samtools view -H --no-PG`.
- The BAM round-trips back to the input SAM exactly.

## One behavioral difference worth naming

On a malformed quality score the boxed path returns `InvalidData` from the iterator, and the `Offset` path returns `InvalidInput` from the encoder. Both are errors and both reject the same inputs; only the kind differs. Say the word if you would rather they matched and I will align them.

Two commits: the override with its tests, and the changelog.
