### PR TITLE
bam/record/codec/encoder: Read the CIGAR operations once per record

### DIFF
--- a/noodles-bam/CHANGELOG.md
+++ b/noodles-bam/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+  * bam/record/codec/encoder: Read the CIGAR operations once per record.
+
+    The alignment span, the read length, and the operation count now come from
+    a single pass rather than one each, which also removes four allocations per
+    record. Output is unchanged.
+
 ## 0.95.0 - 2026-08-21
 
 ### Changed

--- a/noodles-bam/src/record/codec/encoder.rs
+++ b/noodles-bam/src/record/codec/encoder.rs
@@ -15,7 +15,8 @@ mod template_length;
 
 use std::{error, fmt, io};
 
-use noodles_sam::{self as sam, alignment::Record};
+use noodles_core::Position;
+use noodles_sam::{self as sam, alignment::Record, alignment::record::Cigar};
 
 use self::{
     bin::write_bin,
@@ -97,13 +98,19 @@ where
     let mapping_quality = record.mapping_quality().transpose()?;
     write_mapping_quality(dst, mapping_quality);
 
+    // A single pass over the CIGAR operations gives the alignment span, the read length, and the
+    // operation count. Reading them from the record instead parses the operations once each, which
+    // for a text CIGAR means parsing it four times per record.
+    let cigar = record.cigar();
+    let (op_count, alignment_span, read_length) = cigar_stats(&*cigar)?;
+
     // bin
-    let alignment_end = record.alignment_end().transpose()?;
+    let alignment_end = alignment_end(alignment_start, alignment_span);
     write_bin(dst, alignment_start, alignment_end);
 
     // n_cigar_op
-    let base_count = record.sequence().len();
-    let cigar = overflowing_write_cigar_op_count(dst, base_count, &record.cigar())?;
+    let base_count = record.sequence_ref().len();
+    let cigar = overflowing_write_cigar_op_count(dst, base_count, op_count, alignment_span)?;
 
     // flag
     let flags = record.flags()?;
@@ -141,7 +148,6 @@ where
     }
 
     // seq
-    let read_length = record.cigar().read_length()?;
     write_sequence(dst, read_length, record.sequence_ref())?;
 
     // qual
@@ -154,6 +160,42 @@ where
     }
 
     Ok(())
+}
+
+fn cigar_stats<C>(cigar: &C) -> io::Result<(usize, usize, usize)>
+where
+    C: Cigar + ?Sized,
+{
+    let mut op_count = 0;
+    let mut alignment_span = 0;
+    let mut read_length = 0;
+
+    for result in cigar.iter() {
+        let op = result?;
+        let kind = op.kind();
+
+        op_count += 1;
+
+        if kind.consumes_reference() {
+            alignment_span += op.len();
+        }
+
+        if kind.consumes_read() {
+            read_length += op.len();
+        }
+    }
+
+    Ok((op_count, alignment_span, read_length))
+}
+
+fn alignment_end(alignment_start: Option<Position>, alignment_span: usize) -> Option<Position> {
+    let start = alignment_start?;
+
+    if alignment_span == 0 {
+        Some(start)
+    } else {
+        Position::new(usize::from(start) + alignment_span - 1)
+    }
 }
 
 #[cfg(test)]

--- a/noodles-bam/src/record/codec/encoder/cigar.rs
+++ b/noodles-bam/src/record/codec/encoder/cigar.rs
@@ -40,24 +40,22 @@ impl fmt::Display for EncodeError {
 // § 4.2.2 "N_CIGAR_OP field" (2023-11-16): "For an alignment with more [than 65535] CIGAR
 // operations, BAM [...] sets `CIGAR` to `kSmN` as a placeholder, where `k` equals `l_seq`, `m` is
 // the reference sequence length in the alignment..."
-pub(super) fn overflowing_write_cigar_op_count<C>(
+pub(super) fn overflowing_write_cigar_op_count(
     dst: &mut Vec<u8>,
     base_count: usize,
-    cigar: &C,
-) -> io::Result<Option<sam::alignment::record_buf::Cigar>>
-where
-    C: Cigar,
-{
+    op_count: usize,
+    alignment_span: usize,
+) -> io::Result<Option<sam::alignment::record_buf::Cigar>> {
     const OVERFLOWING_OP_COUNT: u16 = 2;
 
-    if let Ok(op_count) = u16::try_from(cigar.len()) {
-        write_u16_le(dst, op_count);
+    if let Ok(n) = u16::try_from(op_count) {
+        write_u16_le(dst, n);
         Ok(None)
     } else {
         write_u16_le(dst, OVERFLOWING_OP_COUNT);
 
         let k = base_count;
-        let m = cigar.alignment_span()?;
+        let m = alignment_span;
 
         Ok(Some(
             [Op::new(Kind::SoftClip, k), Op::new(Kind::Skip, m)]
@@ -111,7 +109,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::iter;
 
     use noodles_sam::alignment::record_buf::Cigar as CigarBuf;
 
@@ -122,16 +119,14 @@ mod tests {
         let mut buf = Vec::new();
 
         buf.clear();
-        let cigar: CigarBuf = [Op::new(Kind::Match, 4)].into_iter().collect();
-        let overflowing_cigar = overflowing_write_cigar_op_count(&mut buf, 4, &cigar)?;
+        let overflowing_cigar = overflowing_write_cigar_op_count(&mut buf, 4, 1, 4)?;
         assert_eq!(buf, [0x01, 0x00]);
         assert!(overflowing_cigar.is_none());
 
         const MAX_CIGAR_OP_COUNT: usize = (1 << 16) - 1;
         buf.clear();
-        let cigar: CigarBuf =
-            iter::repeat_n(Op::new(Kind::Match, 1), MAX_CIGAR_OP_COUNT + 1).collect();
-        let overflowing_cigar = overflowing_write_cigar_op_count(&mut buf, 4, &cigar)?;
+        let overflowing_cigar =
+            overflowing_write_cigar_op_count(&mut buf, 4, MAX_CIGAR_OP_COUNT + 1, 1 << 16)?;
         assert_eq!(buf, [0x02, 0x00]);
         assert_eq!(
             overflowing_cigar,


### PR DESCRIPTION
Encoding one record walks the CIGAR four times:

| line | call | why |
|---|---|---|
| `encoder.rs:101` | `Record::alignment_end` | the bin, via `alignment_span` |
| `encoder.rs:106` | `Cigar::len` | the operation count |
| `encoder.rs:139` | `write_cigar` | the operations themselves |
| `encoder.rs:143` | `Cigar::read_length` | validating the sequence length |

Each of the first, second and fourth goes through `Record::cigar`, which returns `Box<dyn Cigar>`, so it is four allocations as well as four walks. For a `sam::Record` a walk is a parse of the text, so a record with a CIGAR of `95M2I4M` parses it four times to write it once.

The span, the read length and the operation count all fall out of one pass, so this takes one. `Record::sequence_ref` replaces `Record::sequence` for the base count, which drops a fifth allocation, and the operations are still written through `Record::cigar_ref`, so `bam::Record`'s packed fast path is untouched.

`overflowing_write_cigar_op_count` now takes the counts instead of the CIGAR, since it no longer needs to walk it.

## Measurement

Apple M4 Max, 12 performance and 4 efficiency cores, 128 GB, rustc 1.97.1, release with `lto = "fat"` and `codegen-units = 1`, `noodles-bgzf/libdeflate`. Encode is isolated by subtracting a parse-only run from a run writing to `io::sink()`. Best of three, page cache warm.

| encode alone | before | after |
|---|---|---|
| 1,604,108 SAM records | 0.985 s | 0.891 s |
| 654,610 BAM records | 0.383 s | 0.273 s |

The BAM side gains more because its CIGAR walk was already cheap per operation, so the four allocations dominated.

Stacked with #419, which is independent, encoding the same SAM drops to 0.646 s and the same BAM to 0.266 s. BAM to BAM at 16 workers goes from 0.494 s to 0.419 s, against 0.45 s for `samtools view -b -@ 16` on the same file and machine.

## Correctness

Byte-identical output in both directions, `cmp` on the whole file: SAM to BAM and BAM to BAM against what noodles produced before the change. The full workspace test suite passes with `--all-features`.

Two commits: the encoder change, and the changelog.
