### PR TITLE
bam/examples: Add parallel SAM to BAM and BAM to SAM conversions

### DIFF
--- a/noodles-bam/Cargo.toml
+++ b/noodles-bam/Cargo.toml
@@ -34,6 +34,7 @@ noodles-csi = { path = "../noodles-csi", version = "0.61.0" }
 noodles-sam = { path = "../noodles-sam", version = "0.90.0" }
 
 [dev-dependencies]
+rayon = "1.12.0"
 noodles-sam = { path = "../noodles-sam", version = "0.90.0", features = ["async"] }
 tokio = { workspace = true, features = ["io-std", "macros", "rt-multi-thread"] }
 

--- a/noodles-bam/examples/bam_view_parallel.rs
+++ b/noodles-bam/examples/bam_view_parallel.rs
@@ -1,0 +1,90 @@
+//! Converts a BAM file to SAM, formatting records on a thread pool.
+//!
+//! This is the counterpart of `bam_write_parallel`. `bgzf::io::MultithreadedReader` decompresses
+//! on several threads, but the records are formatted into text by whichever thread drives the
+//! writer, and past a few workers that thread is the constraint.
+//!
+//! Records are read into a batch, the batch is formatted in parallel, and the results are written
+//! in order. Unlike the SAM input case there are no byte offsets to find: a batch of records is
+//! already a list of independent units, which is what makes this the simpler direction.
+//!
+//! The output is identical to writing the records one at a time.
+//!
+//! The equivalent of `samtools view -h -o <dst> <src>`.
+
+use std::{
+    env,
+    fs::File,
+    io::{self, BufWriter, Write},
+};
+
+use noodles_bam as bam;
+use noodles_bgzf as bgzf;
+use noodles_sam::{self as sam, alignment::io::Write as _};
+use rayon::prelude::*;
+
+const BATCH_SIZE: usize = 1 << 16;
+
+fn main() -> io::Result<()> {
+    let mut args = env::args().skip(1);
+    let src = args.next().expect("missing src");
+    let dst = args.next().expect("missing dst");
+
+    let worker_count = std::thread::available_parallelism()?;
+
+    let decoder = bgzf::io::MultithreadedReader::with_worker_count(worker_count, File::open(src)?);
+    let mut reader = bam::io::Reader::from(decoder);
+    let header = reader.read_header()?;
+
+    let mut inner = BufWriter::new(File::create(dst)?);
+
+    {
+        let mut writer = sam::io::Writer::new(&mut inner);
+        writer.write_alignment_header(&header)?;
+    }
+
+    let mut batch = vec![bam::Record::default(); BATCH_SIZE];
+
+    loop {
+        let mut filled = 0;
+
+        while filled < BATCH_SIZE {
+            if reader.read_record(&mut batch[filled])? == 0 {
+                break;
+            }
+
+            filled += 1;
+        }
+
+        if filled == 0 {
+            break;
+        }
+
+        let chunk_size = (filled / worker_count).max(1);
+
+        let blocks: Vec<Vec<u8>> = batch[..filled]
+            .par_chunks(chunk_size)
+            .map(|chunk| format(&header, chunk))
+            .collect::<io::Result<_>>()?;
+
+        for block in &blocks {
+            inner.write_all(block)?;
+        }
+
+        if filled < BATCH_SIZE {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn format(header: &sam::Header, records: &[bam::Record]) -> io::Result<Vec<u8>> {
+    let mut writer = sam::io::Writer::new(Vec::new());
+
+    for record in records {
+        writer.write_alignment_record(header, record)?;
+    }
+
+    Ok(writer.into_inner())
+}

--- a/noodles-bam/examples/bam_write_parallel.rs
+++ b/noodles-bam/examples/bam_write_parallel.rs
@@ -1,0 +1,133 @@
+//! Converts a SAM file to BAM, encoding records on a thread pool.
+//!
+//! `bgzf::io::MultithreadedWriter` compresses on several threads, but the records themselves are
+//! parsed and encoded by whichever thread calls the writer. Past the point where compression keeps
+//! up, that thread is the constraint, and adding compression workers does nothing.
+//!
+//! This reads the input in chunks, splits each chunk into one contiguous range per worker aligned
+//! to record boundaries, encodes the ranges in parallel, and writes the results in order. Only the
+//! boundary rule is specific to SAM: records are one line, so a range ends at a line feed.
+//!
+//! The output is identical to writing the records one at a time.
+//!
+//! The equivalent of `samtools view -b -o <dst> <src>`.
+
+use std::{
+    env,
+    fs::File,
+    io::{self, BufReader, Read, Write},
+    ops::Range,
+};
+
+use noodles_bam as bam;
+use noodles_bgzf as bgzf;
+use noodles_sam::{self as sam, alignment::io::Write as _};
+use rayon::prelude::*;
+
+const CHUNK_SIZE: usize = 32 << 20;
+const LINE_FEED: u8 = b'\n';
+
+fn main() -> io::Result<()> {
+    let mut args = env::args().skip(1);
+    let src = args.next().expect("missing src");
+    let dst = args.next().expect("missing dst");
+
+    let worker_count = std::thread::available_parallelism()?;
+
+    let mut reader = sam::io::Reader::new(BufReader::new(File::open(src)?));
+    let header = reader.read_header()?;
+
+    let encoder =
+        bgzf::io::MultithreadedWriter::with_worker_count(worker_count, File::create(dst)?);
+    let mut writer = bam::io::Writer::from(encoder);
+    writer.write_header(&header)?;
+
+    let mut inner = reader.into_inner();
+    let mut buf = vec![0; CHUNK_SIZE];
+    let mut carry_len = 0;
+
+    loop {
+        let mut filled = carry_len;
+
+        while filled < buf.len() {
+            let n = inner.read(&mut buf[filled..])?;
+
+            if n == 0 {
+                break;
+            }
+
+            filled += n;
+        }
+
+        if filled == 0 {
+            break;
+        }
+
+        // Only complete records are handed out. The tail moves to the front for the next round.
+        let end = match buf[..filled].iter().rposition(|&b| b == LINE_FEED) {
+            Some(i) => i + 1,
+            None => filled,
+        };
+
+        let ranges = split(&buf[..end], worker_count.get());
+
+        let blocks: Vec<Vec<u8>> = ranges
+            .par_iter()
+            .map(|range| encode(&header, &buf[range.clone()]))
+            .collect::<io::Result<_>>()?;
+
+        for block in &blocks {
+            writer.get_mut().write_all(block)?;
+        }
+
+        buf.copy_within(end..filled, 0);
+        carry_len = filled - end;
+
+        if filled < CHUNK_SIZE {
+            break;
+        }
+    }
+
+    writer.finish(&header)?;
+
+    Ok(())
+}
+
+/// Splits a buffer of complete records into `n` contiguous ranges, each ending on a record
+/// boundary.
+fn split(src: &[u8], n: usize) -> Vec<Range<usize>> {
+    let mut ranges = Vec::with_capacity(n);
+    let target = (src.len() / n).max(1);
+    let mut start = 0;
+
+    while start < src.len() {
+        let mut end = (start + target).min(src.len());
+
+        if end < src.len() {
+            match src[end..].iter().position(|&b| b == LINE_FEED) {
+                Some(i) => end += i + 1,
+                None => end = src.len(),
+            }
+        }
+
+        ranges.push(start..end);
+        start = end;
+    }
+
+    ranges
+}
+
+fn encode(header: &sam::Header, src: &[u8]) -> io::Result<Vec<u8>> {
+    let mut writer = bam::io::Writer::from(Vec::with_capacity(src.len()));
+
+    for line in src.split(|&b| b == LINE_FEED) {
+        if line.is_empty() {
+            continue;
+        }
+
+        let record = sam::Record::try_from(line)?;
+        writer.write_alignment_record(header, &record)?;
+    }
+
+    Ok(writer.into_inner())
+}


### PR DESCRIPTION
Closes the open half of #424.

`bgzf::io::MultithreadedWriter` compresses on several threads and `bgzf::io::MultithreadedReader` decompresses on several threads, but in both directions the records themselves are handled by whichever thread drives the reader or writer. Past the point where compression keeps up, that thread is the constraint and further workers are idle.

Two examples, one per direction, on an Apple M4 Max with 12 performance and 4 efficiency cores. All outputs verified byte-identical to the one-record-at-a-time path.

**`bam_write_parallel`**, SAM to BAM, 1,604,108 records. Reads the input in chunks, splits each chunk into one contiguous range per worker aligned to record boundaries, encodes the ranges in parallel, writes the results in order.

| | wall |
|---|---|
| one record at a time, any worker count above four | 1.33 s |
| this example | **0.75 s** |
| `samtools view -b -@ 16` | 0.46 s |

**`bam_view_parallel`**, BAM to SAM, 654,610 records. Reads a batch of records and formats the batch in parallel. The simpler direction: a batch is already a list of independent units, so there are no byte offsets to align.

| | wall |
|---|---|
| single-threaded reader | 1.41 s |
| `MultithreadedReader`, 4 workers | 1.04 s |
| `MultithreadedReader`, 16 workers | 1.04 s |
| this example | **0.26 s** |
| `samtools view -h -@ 16` | 0.15 s |
| `samtools view -h -@ 1` | 0.90 s |

The second table is the clearest statement of the problem in this repository: threading the BGZF reader buys 26% and then stops, because the serial part is formatting records, not decompressing blocks.

## Why examples rather than an API

#424 asked whether a threaded record pipeline belongs in noodles. These suggest not: the pattern needs no support from the library, and `examples/` says so without committing you to a surface to maintain.

It is also not always right, which an example can show and an API cannot. The same shape applied to FASTQ makes it **slower**, 0.069 s to 0.166 s, because that path is bounded by I/O rather than by per-record work. Applied to VCF it is worth a great deal: 1.18 s to 0.20 s on 1,375,319 sites-only records, and 1.59 s to 0.29 s on 1,406 records with 2,535 samples, byte-identical in both. Only the boundary rule changes between formats.

Related: #419, #423 and #426 lower the serial per-record cost these examples then parallelise; stacked with the first two, `bam_write_parallel` runs in 0.60 s. #420 asks for a sentence of documentation about the plateau itself.

## Note on the dependency

This adds rayon as a dev-dependency of noodles-bam. It is already in the tree through noodles-bgzf, so it costs nothing to build. If you would rather keep `examples/` dependency-free, the same split works with `std::thread::scope` and a little more code; say the word and I will send that version.

Two commits, one per example.
