### PR TITLE
sam/io/writer/record/data: Write BAM-encoded fields without decoding them

### DIFF
--- a/noodles-sam/CHANGELOG.md
+++ b/noodles-sam/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+  * sam/io/writer/record/data: Write BAM-encoded fields without decoding them.
+
+    Fields that are already encoded, i.e., `DataRef::FieldEncoded`, are now
+    transcoded to text directly rather than decoded into values first. This
+    removes two allocations per record and the value materialized for each
+    field. Output is unchanged.
+
 ## 0.90.0 - 2026-08-21
 
 ### Changed

--- a/noodles-sam/src/io/writer/record.rs
+++ b/noodles-sam/src/io/writer/record.rs
@@ -94,7 +94,7 @@ where
     writer.write_all(DELIMITER)?;
     write_quality_scores(writer, base_count, record.quality_scores_ref())?;
 
-    write_data(writer, record.data())?;
+    write_data(writer, record.data_ref())?;
 
     writeln!(writer)?;
 

--- a/noodles-sam/src/io/writer/record/data.rs
+++ b/noodles-sam/src/io/writer/record/data.rs
@@ -1,11 +1,22 @@
 mod field;
+mod field_encoded;
 
 use std::io::{self, Write};
 
-use self::field::write_field;
-use crate::alignment::record::Data;
+use self::{field::write_field, field_encoded::write_field_encoded_data};
+use crate::alignment::record::{Data, DataRef};
 
-pub(super) fn write_data<'r, W, D>(writer: &mut W, data: D) -> io::Result<()>
+pub(super) fn write_data<W>(writer: &mut W, data: DataRef<'_>) -> io::Result<()>
+where
+    W: Write,
+{
+    match data {
+        DataRef::FieldEncoded(src) => write_field_encoded_data(writer, src),
+        DataRef::Data(d) => write_generic_data(writer, d),
+    }
+}
+
+fn write_generic_data<'r, W, D>(writer: &mut W, data: D) -> io::Result<()>
 where
     W: Write,
     D: Data<'r>,
@@ -40,7 +51,7 @@ mod tests {
         .into_iter()
         .collect();
 
-        write_data(&mut buf, &data)?;
+        write_data(&mut buf, DataRef::Data(Box::new(&data)))?;
 
         assert_eq!(buf, b"\tNH:i:1\tCO:Z:noodles");
 

--- a/noodles-sam/src/io/writer/record/data/field.rs
+++ b/noodles-sam/src/io/writer/record/data/field.rs
@@ -1,6 +1,6 @@
 mod tag;
 mod ty;
-mod value;
+pub(super) mod value;
 
 use std::io::{self, Write};
 

--- a/noodles-sam/src/io/writer/record/data/field/value.rs
+++ b/noodles-sam/src/io/writer/record/data/field/value.rs
@@ -6,9 +6,9 @@ mod string;
 
 use std::io::{self, Write};
 
-use self::{
-    array::write_array, character::write_character, float::write_float, hex::write_hex,
-    string::write_string,
+use self::{array::write_array, character::write_character};
+pub(in crate::io::writer::record::data) use self::{
+    float::write_float, hex::write_hex, string::write_string,
 };
 use crate::{alignment::record::data::field::Value, io::writer::num};
 

--- a/noodles-sam/src/io/writer/record/data/field/value/float.rs
+++ b/noodles-sam/src/io/writer/record/data/field/value/float.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 
 use crate::io::writer::num;
 
-pub(super) fn write_float<W>(writer: &mut W, n: f32) -> io::Result<()>
+pub(in crate::io::writer::record::data) fn write_float<W>(writer: &mut W, n: f32) -> io::Result<()>
 where
     W: Write,
 {

--- a/noodles-sam/src/io/writer/record/data/field/value/hex.rs
+++ b/noodles-sam/src/io/writer/record/data/field/value/hex.rs
@@ -1,6 +1,9 @@
 use std::io::{self, Write};
 
-pub(super) fn write_hex<W>(writer: &mut W, buf: &[u8]) -> io::Result<()>
+pub(in crate::io::writer::record::data) fn write_hex<W>(
+    writer: &mut W,
+    buf: &[u8],
+) -> io::Result<()>
 where
     W: Write,
 {

--- a/noodles-sam/src/io/writer/record/data/field/value/string.rs
+++ b/noodles-sam/src/io/writer/record/data/field/value/string.rs
@@ -1,6 +1,9 @@
 use std::io::{self, Write};
 
-pub(super) fn write_string<W>(writer: &mut W, buf: &[u8]) -> io::Result<()>
+pub(in crate::io::writer::record::data) fn write_string<W>(
+    writer: &mut W,
+    buf: &[u8],
+) -> io::Result<()>
 where
     W: Write,
 {

--- a/noodles-sam/src/io/writer/record/data/field_encoded.rs
+++ b/noodles-sam/src/io/writer/record/data/field_encoded.rs
@@ -1,0 +1,206 @@
+//! Writes BAM-encoded data fields as SAM text.
+//!
+//! This transcodes the binary layout directly. Going through
+//! [`crate::alignment::record::data::field::Value`] instead means materializing a value for every
+//! field of every record, and reaching it through a boxed iterator.
+
+use std::io::{self, Write};
+
+use bstr::BStr;
+
+use super::field::value::{write_float, write_hex, write_string};
+use crate::io::writer::num;
+
+const DELIMITER: u8 = b':';
+const SEPARATOR: u8 = b',';
+const NUL: u8 = 0x00;
+
+pub(super) fn write_field_encoded_data<W>(writer: &mut W, mut src: &[u8]) -> io::Result<()>
+where
+    W: Write,
+{
+    const TAB: u8 = b'\t';
+
+    while !src.is_empty() {
+        writer.write_all(&[TAB])?;
+        write_field(writer, &mut src)?;
+    }
+
+    Ok(())
+}
+
+fn write_field<W>(writer: &mut W, src: &mut &[u8]) -> io::Result<()>
+where
+    W: Write,
+{
+    let tag = split_off::<2>(src)?;
+    writer.write_all(&tag)?;
+    writer.write_all(&[DELIMITER])?;
+
+    let ty = split_off_first(src)?;
+
+    // § 1.5 "The alignment section: optional fields" (2024-11-06): the integer types collapse to
+    // `i` in SAM.
+    let sam_ty = match ty {
+        b'A' => b'A',
+        b'c' | b'C' | b's' | b'S' | b'i' | b'I' => b'i',
+        b'f' => b'f',
+        b'Z' => b'Z',
+        b'H' => b'H',
+        b'B' => b'B',
+        _ => return Err(invalid_data("invalid data field type")),
+    };
+
+    writer.write_all(&[sam_ty])?;
+    writer.write_all(&[DELIMITER])?;
+
+    write_value(writer, src, ty)
+}
+
+fn write_value<W>(writer: &mut W, src: &mut &[u8], ty: u8) -> io::Result<()>
+where
+    W: Write,
+{
+    match ty {
+        b'A' => writer.write_all(&[split_off_first(src)?]),
+        b'c' => num::write_i8(writer, split_off_first(src)? as i8),
+        b'C' => num::write_u8(writer, split_off_first(src)?),
+        b's' => num::write_i16(writer, i16::from_le_bytes(split_off(src)?)),
+        b'S' => num::write_u16(writer, u16::from_le_bytes(split_off(src)?)),
+        b'i' => num::write_i32(writer, i32::from_le_bytes(split_off(src)?)),
+        b'I' => num::write_u32(writer, u32::from_le_bytes(split_off(src)?)),
+        b'f' => write_float(writer, f32::from_le_bytes(split_off(src)?)),
+        b'Z' => write_string(writer, split_off_nul_terminated(src)?),
+        b'H' => write_hex(writer, split_off_nul_terminated(src)?),
+        b'B' => write_array(writer, src),
+        _ => Err(invalid_data("invalid data field type")),
+    }
+}
+
+fn write_array<W>(writer: &mut W, src: &mut &[u8]) -> io::Result<()>
+where
+    W: Write,
+{
+    let subtype = split_off_first(src)?;
+
+    if !matches!(subtype, b'c' | b'C' | b's' | b'S' | b'i' | b'I' | b'f') {
+        return Err(invalid_data("invalid array subtype"));
+    }
+
+    writer.write_all(&[subtype])?;
+
+    let len = u32::from_le_bytes(split_off(src)?);
+
+    for _ in 0..len {
+        writer.write_all(&[SEPARATOR])?;
+        write_value(writer, src, subtype)?;
+    }
+
+    Ok(())
+}
+
+fn split_off<const N: usize>(src: &mut &[u8]) -> io::Result<[u8; N]> {
+    if src.len() < N {
+        return Err(unexpected_eof());
+    }
+
+    let (buf, rest) = src.split_at(N);
+    *src = rest;
+
+    // SAFETY: `buf` is `N` bytes.
+    Ok(buf.try_into().unwrap())
+}
+
+fn split_off_first(src: &mut &[u8]) -> io::Result<u8> {
+    split_off::<1>(src).map(|buf| buf[0])
+}
+
+fn split_off_nul_terminated<'a>(src: &mut &'a [u8]) -> io::Result<&'a BStr> {
+    let i = src
+        .iter()
+        .position(|&b| b == NUL)
+        .ok_or_else(unexpected_eof)?;
+    let (buf, rest) = src.split_at(i);
+    *src = &rest[1..];
+    Ok(BStr::new(buf))
+}
+
+fn invalid_data(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+fn unexpected_eof() -> io::Error {
+    io::Error::from(io::ErrorKind::UnexpectedEof)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_field_encoded_data() -> io::Result<()> {
+        fn t(src: &[u8], expected: &[u8]) -> io::Result<()> {
+            let mut buf = Vec::new();
+            write_field_encoded_data(&mut buf, src)?;
+            assert_eq!(buf, expected);
+            Ok(())
+        }
+
+        t(&[], b"")?;
+        t(&[b'N', b'H', b'C', 0x01], b"\tNH:i:1")?;
+        t(&[b'N', b'H', b'c', 0xff], b"\tNH:i:-1")?;
+        t(&[b'N', b'H', b's', 0xff, 0xff], b"\tNH:i:-1")?;
+        t(&[b'N', b'H', b'S', 0x01, 0x00], b"\tNH:i:1")?;
+        t(&[b'N', b'H', b'i', 0xff, 0xff, 0xff, 0xff], b"\tNH:i:-1")?;
+        t(&[b'N', b'H', b'I', 0x01, 0x00, 0x00, 0x00], b"\tNH:i:1")?;
+        t(b"COAn", b"\tCO:A:n")?;
+        t(&[b'F', b'Z', b'f', 0x00, 0x00, 0x80, 0x3f], b"\tFZ:f:1")?;
+        t(
+            &[b'C', b'O', b'Z', b'n', b'd', b'l', b's', 0x00],
+            b"\tCO:Z:ndls",
+        )?;
+        t(
+            &[b'C', b'O', b'H', b'C', b'A', b'F', b'E', 0x00],
+            b"\tCO:H:CAFE",
+        )?;
+
+        t(
+            &[b'F', b'Z', b'B', b'C', 0x02, 0x00, 0x00, 0x00, 0x07, 0x0d],
+            b"\tFZ:B:C,7,13",
+        )?;
+
+        // Two fields in one buffer.
+        t(
+            &[
+                b'N', b'H', b'C', 0x01, b'R', b'G', b'Z', b'r', b'g', b'0', 0x00,
+            ],
+            b"\tNH:i:1\tRG:Z:rg0",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_field_encoded_data_with_invalid_input() {
+        // A truncated value.
+        let mut buf = Vec::new();
+        assert!(matches!(
+            write_field_encoded_data(&mut buf, &[b'N', b'H', b'i', 0x00]),
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof
+        ));
+
+        // An unknown type.
+        let mut buf = Vec::new();
+        assert!(matches!(
+            write_field_encoded_data(&mut buf, &[b'N', b'H', b'?', 0x00]),
+            Err(e) if e.kind() == io::ErrorKind::InvalidData
+        ));
+
+        // An unterminated string.
+        let mut buf = Vec::new();
+        assert!(matches!(
+            write_field_encoded_data(&mut buf, b"COZn"),
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof
+        ));
+    }
+}


### PR DESCRIPTION
Addresses the SAM-writer half of #421.

`write_data` took `Record::data`, which is a `Box<dyn Data>`, and then called `Data::iter`, which boxes again. Writing one record's data allocated twice before a byte was written, and materialized an `alignment::record::data::field::Value` for every field only to format it and drop it. Profiling a BAM to SAM conversion after #426 put `write_data` first at 367 samples and the allocator second at about 279, with roughly 1.3 million allocations for a 654,610-record file.

`bam::Record::data_ref` already returns `DataRef::FieldEncoded`, the fields exactly as they are laid out in the file, but the only consumer of that variant was `noodles-bam`'s own encoder. This adds the other one: a transcoder that walks the binary layout and writes SAM text directly, without an intermediate value.

It reuses the existing `write_float`, `write_string`, `write_hex` and `num::write_*`, so the bytes and the validation are the same by construction. Records whose fields are not already encoded, e.g., `RecordBuf`, keep the previous path.

## Measurement

Apple M4 Max, 12 performance and 4 efficiency cores, rustc 1.97.1, release with `lto = "fat"` and `codegen-units = 1`. `CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam`, 654,610 records. Best of three, page cache warm.

| | wall |
|---|---|
| before | 0.826 s |
| after | **0.785 s** |

5%. Smaller than the allocation count suggested, which is worth saying plainly: most of `write_data`'s cost is the formatting itself, not the boxes. The change still stands on removing two allocations and a value materialization per record, and it composes with #426, but I am not going to claim more for it than the number.

## Correctness

- Output byte-identical to what noodles wrote before the change, `cmp` on the whole 654,610-record file.
- Output byte-identical to `samtools view --no-PG -h` on the same input.
- Unit tests cover every type and subtype, both integer signs, and three malformed inputs: a truncated value, an unknown type byte, and an unterminated string.

Two commits: the transcoder, and the changelog.
