### PR TITLE
vcf/io/writer/record/samples: Write already-encoded samples as they are

### DIFF
--- a/noodles-vcf/CHANGELOG.md
+++ b/noodles-vcf/CHANGELOG.md
@@ -17,6 +17,12 @@
 
     Empty inputs now return `io::ErrorKind::UnexpectedEof`.
 
+  * vcf/io/writer/record/samples: Write already-encoded samples as they are.
+
+    Samples that are already VCF text, i.e., those of a parsed `Record`, are
+    now written directly rather than decoded into values and formatted again.
+    Output is unchanged.
+
 ## 0.93.0 - 2026-08-21
 
 ### Changed
@@ -1277,7 +1283,6 @@
   * vcf/record/genotypes/genotype/field: Remove `Field`.
 
     Use `(Key, Option<Value>)` instead.
-
 
 ## 0.23.0 - 2022-11-29
 

--- a/noodles-vcf/src/io/writer/record/samples.rs
+++ b/noodles-vcf/src/io/writer/record/samples.rs
@@ -49,6 +49,11 @@ where
     W: Write,
     S: Samples,
 {
+    // The samples of a parsed record are already the output: the keys, a tab, then the samples.
+    if let Some(src) = samples.as_text() {
+        return writer.write_all(src.as_bytes()).map_err(WriteError::Io);
+    }
+
     write_keys(writer, samples.column_names(header)).map_err(WriteError::InvalidKeys)?;
 
     for sample in samples.iter() {

--- a/noodles-vcf/src/record/samples.rs
+++ b/noodles-vcf/src/record/samples.rs
@@ -119,6 +119,10 @@ impl crate::variant::record::Samples for Samples<'_> {
         )
     }
 
+    fn as_text(&self) -> Option<&str> {
+        Some(self.0)
+    }
+
     fn iter(
         &self,
     ) -> Box<dyn Iterator<Item = Box<dyn crate::variant::record::samples::Sample + '_>> + '_> {

--- a/noodles-vcf/src/variant/record/samples.rs
+++ b/noodles-vcf/src/variant/record/samples.rs
@@ -60,6 +60,15 @@ pub trait Samples {
 
     /// Returns an iterator over samples.
     fn iter(&self) -> Box<dyn Iterator<Item = Box<dyn Sample + '_>> + '_>;
+
+    /// Returns the samples as VCF text, if they are already in that form.
+    ///
+    /// A writer can hand these straight to its output instead of decoding every value only to
+    /// format it again.
+    #[doc(hidden)]
+    fn as_text(&self) -> Option<&str> {
+        None
+    }
 }
 
 impl Samples for Box<dyn Samples + '_> {
@@ -92,5 +101,9 @@ impl Samples for Box<dyn Samples + '_> {
 
     fn iter(&self) -> Box<dyn Iterator<Item = Box<dyn Sample + '_>> + '_> {
         (**self).iter()
+    }
+
+    fn as_text(&self) -> Option<&str> {
+        (**self).as_text()
     }
 }


### PR DESCRIPTION
Closes #425.

Writing the samples of a record decoded every value and formatted it again. Decoding a value calls `header.formats().get(key)`, a SipHash of the FORMAT key string, so a record with 2,535 samples and five keys hashed a key about 12,000 times to produce text that was already sitting in the record: `record::Samples` is a `&str` over the samples of the line, FORMAT column included.

`variant::record::samples::Samples` gains `as_text`, which returns the samples when they are already VCF text. `record::Samples` returns its slice. Everything else keeps the default of `None` and the previous path, so `RecordBuf` and BCF records are unaffected.

## Measurement

Apple M4 Max, 12 performance and 4 efficiency cores, rustc 1.97.1, release with `lto = "fat"` and `codegen-units = 1`. Best of three, page cache warm.

| input | before | after |
|---|---|---|
| `1000G.phase3.chr20`, 1,406 records, 2,535 samples | 1.587 s | **0.019 s** |
| `dbsnp_138.b37.1.1-65M`, 1,375,319 records, no samples | 1.178 s | 1.150 s |

For reference, `bcftools view -O v` takes 0.31 s on the first file.

The second file is the control: it has no samples, so nothing short-circuits and nothing changes.

## Correctness

Output byte-identical to what noodles wrote before the change, `cmp` on the whole file. That is the meaningful check here: the fast path is only correct if the previous path already reproduced these bytes, and it did.

## One thing this does not do, deliberately

The same trick would apply to `INFO`, which is also a `&str` on a parsed record, and that is where the remaining 1.15 s of the second file goes. It is **not** the same change: noodles currently reformats floats in `INFO`, so `AF=6.146e-03` in the input comes back as `AF=0.006146`. Writing that field verbatim would change the output, which is a behavior change rather than an optimization, and arguably a fix for the round-trip in #413. I have left it alone because those are your calls, not mine.

Two commits: the change, and the changelog.
