### PR TITLE
vcf/io/writer/record/info: Write already-encoded fields as they are

### DIFF
--- a/noodles-vcf/CHANGELOG.md
+++ b/noodles-vcf/CHANGELOG.md
@@ -17,6 +17,15 @@
 
     Empty inputs now return `io::ErrorKind::UnexpectedEof`.
 
+  * vcf/io/writer/record/info: Write already-encoded fields as they are.
+
+    Fields that are already VCF text, i.e., those of a parsed `Record`, are now
+    written directly rather than decoded into values and formatted again.
+
+    This is an observable change: a float is no longer normalized, so
+    `AF=6.146e-03` is written back as it was read rather than as
+    `AF=0.006146`. Records built programmatically are unaffected.
+
 ## 0.93.0 - 2026-08-21
 
 ### Changed
@@ -1277,7 +1286,6 @@
   * vcf/record/genotypes/genotype/field: Remove `Field`.
 
     Use `(Key, Option<Value>)` instead.
-
 
 ## 0.23.0 - 2022-11-29
 

--- a/noodles-vcf/src/io/writer/record/info.rs
+++ b/noodles-vcf/src/io/writer/record/info.rs
@@ -43,6 +43,17 @@ where
 {
     const DELIMITER: &[u8] = b";";
 
+    // The fields of a parsed record are already the output. An empty set of fields is still
+    // written as missing rather than as nothing.
+    if let Some(src) = info.as_text() {
+        let buf = if src.is_empty() {
+            MISSING
+        } else {
+            src.as_bytes()
+        };
+        return writer.write_all(buf).map_err(WriteError::Io);
+    }
+
     if info.is_empty() {
         writer.write_all(MISSING).map_err(WriteError::Io)?;
     } else {

--- a/noodles-vcf/src/record/info.rs
+++ b/noodles-vcf/src/record/info.rs
@@ -57,6 +57,10 @@ impl AsRef<str> for Info<'_> {
 }
 
 impl crate::variant::record::Info for Info<'_> {
+    fn as_text(&self) -> Option<&str> {
+        Some(self.0)
+    }
+
     fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/noodles-vcf/src/variant/record/info.rs
+++ b/noodles-vcf/src/variant/record/info.rs
@@ -27,6 +27,15 @@ pub trait Info {
         &'a self,
         header: &'h Header,
     ) -> Box<dyn Iterator<Item = io::Result<(&'a str, Option<Value<'a>>)>> + 'a>;
+
+    /// Returns the fields as VCF text, if they are already in that form.
+    ///
+    /// A writer can hand these straight to its output instead of decoding every value only to
+    /// format it again.
+    #[doc(hidden)]
+    fn as_text(&self) -> Option<&str> {
+        None
+    }
 }
 
 impl Info for Box<dyn Info + '_> {
@@ -51,5 +60,9 @@ impl Info for Box<dyn Info + '_> {
         header: &'h Header,
     ) -> Box<dyn Iterator<Item = io::Result<(&'a str, Option<Value<'a>>)>> + 'a> {
         (**self).iter(header)
+    }
+
+    fn as_text(&self) -> Option<&str> {
+        (**self).as_text()
     }
 }


### PR DESCRIPTION
The counterpart of #429, for `INFO` rather than the samples, and unlike that one **this changes the output**. I would rather lead with that than bury it.

`record::Info` is a `&str` over the fields of the line, but the writer decoded every value and formatted it again. `variant::record::Info` gains `as_text`, returning the fields when they are already VCF text; `record::Info` returns its slice, everything else keeps the default of `None` and the previous path. An empty set of fields is still written as missing rather than as nothing.

## The behavior change

Floats are no longer normalized. A record read as `AF=6.146e-03` is written back that way rather than as `AF=0.006146`. Both are valid per § 1.3, and the records now reproduce their input exactly, but anyone comparing output byte-for-byte against a previous noodles version will see it.

How much of a file it touches depends entirely on the file:

| file | records changed |
|---|---|
| `dbsnp_138.b37.1.1-65M`, 1,375,319 records | **0** |
| `1000G.phase3.chr20`, 1,406 records | **1,235** |

The first has no scientific-notation floats and is byte-identical before and after. The second is mostly floats.

This is the round-trip question in #413 showing up in a second place: today a VCF read and written by noodles is not the file that was read, and this makes the `INFO` column faithful. Whether that is a fix or a regression is your call, and if you would rather have it behind an option like the one proposed in #414, say so and I will send that instead.

## Measurement

Apple M4 Max, 12 performance and 4 efficiency cores, rustc 1.97.1, release with `lto = "fat"` and `codegen-units = 1`. Best of three, page cache warm.

| | wall |
|---|---|
| before | 1.178 s |
| after | **0.455 s** |
| `bcftools view -O v` | 0.81 s |

2.6x, on the file where the output does not change at all.

## Composition

Independent of #429, which does the same for the samples and is not a behavior change, because there the previous path already reproduced the input bytes. Together they cover both halves of what a VCF record spends its time re-encoding.

Two commits: the change, and the changelog.
